### PR TITLE
10 seconds (even 30 seconds) not enough to install Joomla: change timeout to 60 seconds

### DIFF
--- a/src/JoomlaBrowser.php
+++ b/src/JoomlaBrowser.php
@@ -142,7 +142,7 @@ class JoomlaBrowser extends WebDriver
 
         // Wait while Joomla gets installed
         $this->debug('I wait for Joomla being installed');
-        $I->waitForText('Congratulations! Joomla! is now installed.', 10, ['xpath' => '//h3']);
+        $I->waitForText('Congratulations! Joomla! is now installed.', 60, ['xpath' => '//h3']);
         $this->debug('Joomla is now installed');
         $I->see('Congratulations! Joomla! is now installed.',['xpath' => '//h3']);
     }


### PR DESCRIPTION
Weblinks tests fail with timeout on installing Joomla, as it takes more than 10 seconds to delete and recreate all tables. With this PR, the timeout is 60 seconds, and it passes.