### PR TITLE
Revert "move language selector to strict locator"

### DIFF
--- a/src/JoomlaBrowser.php
+++ b/src/JoomlaBrowser.php
@@ -84,10 +84,10 @@ class JoomlaBrowser extends WebDriver
         $I->dontSeeElement(['id' => 'ftp']);
         // I Wait for the text Main Configuration, meaning that the page is loaded
         $this->debug('I wait for Main Configuration');
-        $I->waitForElement(['id' => 'jform_language'], 10);
+        $I->waitForElement('#jform_language', 10);
 
         $I->debug('I select en-GB as installation language');
-        $I->selectOptionInChosen(['id' => 'jform_language'], 'English (United Kingdom)');
+        $I->selectOptionInChosen('#jform_language', 'English (United Kingdom)');
         $this->debug('I fill Site Name');
         $I->fillField(['id' => 'jform_site_name'], 'Joomla CMS test');
         $this->debug('I fill Site Description');


### PR DESCRIPTION
Reverts joomla-projects/joomla-browser#5

reverts because selenium doesn't see hidden elements