### PR TITLE
Updating Uninstall Extension Function

### DIFF
--- a/src/JoomlaBrowser.php
+++ b/src/JoomlaBrowser.php
@@ -296,11 +296,14 @@ class JoomlaBrowser extends WebDriver
 	}
 
 	/**
-	 * Uninstall Extension based on a name
+	 * Function to uninstall Extension
 	 *
-	 * @param   string  $extensionName  Is important to use a specific
+	 * @param   String  $extensionName  Name of the Extension
+	 * @param   bool    $selectAll      Do we need to delete all the search Result Items
+	 *
+	 * @return void
 	 */
-	public function uninstallExtension($extensionName)
+	public function uninstallExtension($extensionName, $selectAll = false)
 	{
 		$I = $this;
 		$I->amOnPage('/administrator/index.php?option=com_installer&view=manage');
@@ -308,7 +311,14 @@ class JoomlaBrowser extends WebDriver
 		$I->fillField(['id' => 'filter_search'], $extensionName);
 		$I->click(['xpath' => "//button[@type='submit' and @data-original-title='Search']"]);
 		$I->waitForElement(['id' => 'manageList'],'30');
-		$I->click(['xpath' => "//input[@id='cb0']"]);
+		if($selectAll == true)
+		{
+			$I->click(['xpath' => "//input[@onclick='Joomla.checkAll(this)']"]);
+		}
+		else
+		{
+			$I->click(['xpath' => "//input[@id='cb0']"]);
+		}
 		$I->click(['xpath' => "//div[@id='toolbar-delete']/button"]);
 		$I->waitForText('was successful','30', ['id' => 'system-message-container']);
 		$I->see('was successful', ['id' => 'system-message-container']);


### PR DESCRIPTION
This update is to make sure that during Uninstallation of a extension if we need to remove all the items from search result, we can just set the second parameter to True and pass it to the function. Codeception will select all the items and do a combined Uninstallation