### PR TITLE
Add Api Documentation Generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,35 +12,12 @@
 Joomla Browser is a Codeception.com Module. It allows to build `system tests` for a Joomla site much faster providing a set of predefined tasks. 
 
 In between the available functions you can find:
+* install joomla
+* do administrator login
+* enable plugin
+* select option in chosen
 
-* INSTALLATION:
-  * install joomla
-  * install Joomla removing Installation Folder
-  * install Joomla Multilingual Site
-* ADMINISTRATOR:
-  * do administrator login
-  * do administrator logout
-  * set error reporting to development
-  * search for item
-  * check for item existence
-  * EXTENSION MANAGER
-    * install extension from Folder
-    * install extension from url
-    * enable plugin
-    * uninstall extension
-    * search result plugin name
-* FRONTEND:
-  * do frontend login
-* ADMINISTRATOR USER INTERFACE:
-  * select option in chosen
-  * select Option In Radio Field
-  * select Multiple Options In Chosen
-* OTHERS:
-  * check for php notices or warnings
-
-
-The Joomla Browser is constantly evolving and more methods are being added every month. 
-To find a full list of them check the public methods at: https://github.com/joomla-projects/joomla-browser/blob/develop/src/JoomlaBrowser.php
+Check the full list at: [the documentation](https://github.com/joomla-projects/joomla-browser/blob/develop/docs/api.php)
 
 
 ## Joomla Browser in action
@@ -103,3 +80,7 @@ You should remove the WebDriver module and replace it with the JoomlaBrowser mod
         AcceptanceHelper:
             ...
 ```
+
+# Releasing
+## Generate the docs
+type: `vendor/bin/robo generate:api-documentation` in your command line tool. This will generate 

--- a/RoboFile.php
+++ b/RoboFile.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * This is project's console commands configuration for Robo task runner.
+ *
+ * @see http://robo.li/
+ */
+class RoboFile extends \Robo\Tasks
+{
+	public function generateApiDocumentation()
+	{
+		$this->taskGenDoc('docs/api.md')
+			->docClass('Codeception\Module\JoomlaBrowser')
+			->filterMethods(function(\ReflectionMethod $r) {return ($r->isPublic() && $r->class == 'Codeception\Module\JoomlaBrowser');})
+			->processClass(false)
+			->processClassSignature(false)
+			->processClassDocBlock(false)
+			->processMethod(true)
+			->processMethodSignature(function(\ReflectionMethod $r, $text) {return "#### ". substr($text, 13);})
+			->processMethodDocBlock(function(\ReflectionMethod $r, $text) {var_dump($r);var_dump($text);return $text;})
+			->processProperty(false)
+			->processPropertySignature(false)
+			->processPropertyDocBlock(false)
+			//->reorder(false)
+			//->reorderMethods(false)
+			//->prepend(false)
+			//->append('test')
+			->run();
+	}
+}

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,9 @@
         "php": ">=5.3.0",
         "codeception/codeception": "2.*"
     },
+    "require-dev": {
+        "codegyre/robo": "*"
+    },
     "autoload": {
         "psr-4": {
             "Codeception\\Module\\": "src"

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,118 @@
+
+
+
+####  doAdministratorLogin() 
+Function to Do Admin Login In Joomla!
+
+####  doFrontEndLogin() 
+Function to Do frontend Login in Joomla!
+
+####  installJoomla() 
+Installs Joomla
+
+####  installJoomlaRemovingInstallationFolder() 
+Install Joomla removing the Installation folder at the end of the execution
+
+####  installJoomlaMultilingualSite($languages = null) 
+Installs Joomla with Multilingual Feature active
+
+ * `param`   array  $languages  Array containing the language names to be installed
+
+ * `example:` $I->installJoomlaMultilingualSite(['Spanish', 'French']);
+
+####  setErrorReportingToDevelopment() 
+Sets in Adminitrator->Global Configuration the Error reporting to Development
+
+@note: doAdminLogin() before
+
+####  installExtensionFromDirectory($path, $type = null) 
+Installs a Extension in Joomla that is located in a folder inside the server
+
+ * `param`   String  $path  Path for the Extension
+ * `param`   string  $type  Type of Extension
+
+@note: doAdminLogin() before
+
+####  installExtensionFromUrl($url, $type = null) 
+Installs a Extension in Joomla that is located in a url
+
+ * `param`   String  $url   Url address to the .zip file
+ * `param`   string  $type  Type of Extension
+
+@note: doAdminLogin() before
+
+####  checkForPhpNoticesOrWarnings($page = null) 
+Function to check for PHP Notices or Warnings
+
+ * `param string` $page Optional, if not given checks will be done in the current page
+
+@note: doAdminLogin() before
+
+####  selectOptionInRadioField($label, $option) 
+Selects an option in a Joomla Radio Field based on its label
+
+@return void
+
+####  selectOptionInChosen($label, $option) 
+Selects an option in a Chosen Selector based on its label
+
+@return void
+
+####  selectMultipleOptionsInChosen($label, $options) 
+Selects one or more options in a Chosen Multiple Select based on its label.
+
+ * `param`   string  $label    Label of the select field
+ * `param`   array   $options  Array of options to be selected
+
+@return void
+
+####  doAdministratorLogout() 
+Function to Logout from Administrator Panel in Joomla.
+
+@return void
+
+####  enablePlugin($pluginName) 
+Function to Enable a Plugin.
+
+ * `param`   string  $pluginName  Name of the Plugin
+
+@return void
+
+####  uninstallExtension($extensionName) 
+Uninstall Extension based on a name
+
+ * `param`   string  $extensionName  Is important to use a specific
+
+####  searchForItem($name = null, $options = null) 
+Function to Search For an Item in Joomla! Administrator Lists views
+
+ * `param`   String  $name     Name of the Item which we need to Search. If null it cleans the searchbox
+ * `param`   array   $options  Optional Array containing the locators of the search buttons
+
+@return void
+
+####  checkExistenceOf($name) 
+Function to Check of the Item Exist in Search Results in Administrator List.
+
+note: on long lists of items the item that your are looking for may not appear in the first page. We recommend
+the usage of searchForItem method before using the current method.
+
+ * `param`   String  $name  Name of the Item which we are Searching For
+
+@return void
+
+####  checkAllResults() 
+Function to select all the item in the Search results in Administrator List
+
+Note: We recommend use of checkAllResults function only after searchForItem to be sure you are selecting only the desired result set
+
+@return void
+
+####  installLanguage($languageName) 
+Function to install a language through the interface
+
+ * `param string` $languageName Name of the language you want to install
+
+@return void
+
+

--- a/src/JoomlaBrowser.php
+++ b/src/JoomlaBrowser.php
@@ -230,50 +230,50 @@ class JoomlaBrowser extends WebDriver
         $I->see('Configuration successfully saved.',['id' => 'system-message-container']);
     }
 
-	/**
-	 * Installs a Extension in Joomla that is located in a folder inside the server
-	 *
-	 * @param   String  $path  Path for the Extension
-	 * @param   string  $type  Type of Extension
-	 *
-	 * @note: doAdminLogin() before
-	 *
-	 * @deprecated  since Joomla 3.4.4-dev. Use installExtensionFromFolder($path, $type = 'Extension') instead.
-	 */
-	public function installExtensionFromDirectory($path, $type = 'Extension')
+    /**
+     * Installs a Extension in Joomla that is located in a folder inside the server
+     *
+     * @param   String  $path  Path for the Extension
+     * @param   string  $type  Type of Extension
+     *
+     * @note: doAdminLogin() before
+     *
+     * @deprecated  since Joomla 3.4.4-dev. Use installExtensionFromFolder($path, $type = 'Extension') instead.
+     */
+    public function installExtensionFromDirectory($path, $type = 'Extension')
     {
         $this->debug('Suggested to use installExtensionFromFolder instead of installExtensionFromDirectory');
         $this->installExtensionFromFolder($path, $type);
     }
 
-	/**
-	 * Installs a Extension in Joomla that is located in a folder inside the server
-	 *
-	 * @param   String  $path  Path for the Extension
-	 * @param   string  $type  Type of Extension
-	 *
-	 * @note: doAdminLogin() before
-	 */
-	public function installExtensionFromFolder($path, $type = 'Extension')
-	{
-		$I = $this;
-		$I->amOnPage('/administrator/index.php?option=com_installer');
-		$I->waitForText('Extensions: Install','30', ['css' => 'H1']);
-		$I->click(['link' => 'Install from Folder']);
-		$this->debug('I enter the Path');
-		$I->fillField(['id' => 'install_directory'], $path);
-		// @todo: we need to find a better locator for the following Install button
-		$I->click(['xpath' => "//input[contains(@onclick,'Joomla.submitbutton3()')]"]); // Install button
-		$I->waitForText('was successful','30', ['id' => 'system-message-container']);
-		if ($type == 'Extension')
-		{
-			$this->debug('Extension successfully installed from ' . $path);
-		}
-		if ($type == 'Plugin')
-		{
-			$this->debug('Installing plugin was successful.' . $path);
-		}
-	}
+    /**
+     * Installs a Extension in Joomla that is located in a folder inside the server
+     *
+     * @param   String  $path  Path for the Extension
+     * @param   string  $type  Type of Extension
+     *
+     * @note: doAdminLogin() before
+     */
+    public function installExtensionFromFolder($path, $type = 'Extension')
+    {
+        $I = $this;
+        $I->amOnPage('/administrator/index.php?option=com_installer');
+        $I->waitForText('Extensions: Install','30', ['css' => 'H1']);
+        $I->click(['link' => 'Install from Folder']);
+        $this->debug('I enter the Path');
+        $I->fillField(['id' => 'install_directory'], $path);
+        // @todo: we need to find a better locator for the following Install button
+        $I->click(['xpath' => "//input[contains(@onclick,'Joomla.submitbutton3()')]"]); // Install button
+        $I->waitForText('was successful','30', ['id' => 'system-message-container']);
+        if ($type == 'Extension')
+        {
+            $this->debug('Extension successfully installed from ' . $path);
+        }
+        if ($type == 'Plugin')
+        {
+            $this->debug('Installing plugin was successful.' . $path);
+        }
+    }
     /**
      * Installs a Extension in Joomla that is located in a url
      *
@@ -400,117 +400,117 @@ class JoomlaBrowser extends WebDriver
         $I->waitForElement(['id' => 'mod-login-username'], 10);
     }
 
-	/**
-	 * Function to Enable a Plugin
-	 *
-	 * @param   String  $pluginName  Name of the Plugin
-	 *
-	 * @return void
-	 */
-	public function enablePlugin($pluginName)
-	{
-		$I = $this;
-		$I->amOnPage('/administrator/index.php?option=com_plugins');
-		$this->debug('I check for Notices and Warnings');
-		$this->checkForPhpNoticesOrWarnings();
-		$I->searchForItem($pluginName);
-		$I->waitForElement($this->searchResultPluginName($pluginName), 30);
-		$I->checkExistenceOf($pluginName);
-		$I->click(['xpath' => "//input[@id='cb0']"]);
-		$I->click(['xpath' => "//div[@id='toolbar-publish']/button"]);
-		$I->see('successfully enabled', ['id' => 'system-message-container']);
-	}
+    /**
+     * Function to Enable a Plugin
+     *
+     * @param   String  $pluginName  Name of the Plugin
+     *
+     * @return void
+     */
+    public function enablePlugin($pluginName)
+    {
+        $I = $this;
+        $I->amOnPage('/administrator/index.php?option=com_plugins');
+        $this->debug('I check for Notices and Warnings');
+        $this->checkForPhpNoticesOrWarnings();
+        $I->searchForItem($pluginName);
+        $I->waitForElement($this->searchResultPluginName($pluginName), 30);
+        $I->checkExistenceOf($pluginName);
+        $I->click(['xpath' => "//input[@id='cb0']"]);
+        $I->click(['xpath' => "//div[@id='toolbar-publish']/button"]);
+        $I->see('successfully enabled', ['id' => 'system-message-container']);
+    }
 
-	/**
-	 * Function to return Path for the Plugin Name to be searched for
-	 *
-	 * @param   String  $pluginName  Name of the Plugin
-	 *
-	 * @return string
-	 */
-	private function searchResultPluginName($pluginName)
-	{
-		$path = "//form[@id='adminForm']/div/table/tbody/tr[1]/td[4]/a[contains(text(), '" . $pluginName . "')]";
+    /**
+     * Function to return Path for the Plugin Name to be searched for
+     *
+     * @param   String  $pluginName  Name of the Plugin
+     *
+     * @return string
+     */
+    private function searchResultPluginName($pluginName)
+    {
+        $path = "//form[@id='adminForm']/div/table/tbody/tr[1]/td[4]/a[contains(text(), '" . $pluginName . "')]";
 
-		return $path;
-	}
+        return $path;
+    }
 
-	/**
-	 * Uninstall Extension based on a name
-	 *
-	 * @param   string  $extensionName  Is important to use a specific
-	 */
-	public function uninstallExtension($extensionName)
-	{
-		$I = $this;
-		$I->amOnPage('/administrator/index.php?option=com_installer&view=manage');
-		$I->waitForText('Extensions: Manage','30', ['css' => 'H1']);
-		$I->searchForItem($extensionName);
-		$I->waitForElement(['id' => 'manageList'],'30');
-		$I->click(['xpath' => "//input[@id='cb0']"]);
-		$I->click(['xpath' => "//div[@id='toolbar-delete']/button"]);
-		$I->waitForText('was successful','30', ['id' => 'system-message-container']);
-		$I->see('was successful', ['id' => 'system-message-container']);
-		$I->searchForItem($extensionName);
-		$I->waitForText('There are no extensions installed matching your query.', 30, ['class' => 'alert-no-items']);
-		$I->see('There are no extensions installed matching your query.', ['class' => 'alert-no-items']);
-		$this->debug('Extension successfully uninstalled');
-	}
+    /**
+     * Uninstall Extension based on a name
+     *
+     * @param   string  $extensionName  Is important to use a specific
+     */
+    public function uninstallExtension($extensionName)
+    {
+        $I = $this;
+        $I->amOnPage('/administrator/index.php?option=com_installer&view=manage');
+        $I->waitForText('Extensions: Manage','30', ['css' => 'H1']);
+        $I->searchForItem($extensionName);
+        $I->waitForElement(['id' => 'manageList'],'30');
+        $I->click(['xpath' => "//input[@id='cb0']"]);
+        $I->click(['xpath' => "//div[@id='toolbar-delete']/button"]);
+        $I->waitForText('was successful','30', ['id' => 'system-message-container']);
+        $I->see('was successful', ['id' => 'system-message-container']);
+        $I->searchForItem($extensionName);
+        $I->waitForText('There are no extensions installed matching your query.', 30, ['class' => 'alert-no-items']);
+        $I->see('There are no extensions installed matching your query.', ['class' => 'alert-no-items']);
+        $this->debug('Extension successfully uninstalled');
+    }
 
-	/**
-	 * Function to Search For an Item in Joomla! Administrator Lists views
-	 *
-	 * @param   String  $name  Name of the Item which we need to Search
-	 *
-	 * @return void
-	 */
-	public function searchForItem($name = null)
-	{
-		$I = $this;
-		if($name)
-		{
-			$I->debug("Searching for $name");
-			$I->fillField(['id' => "filter_search"],$name);
-			$I->click(['xpath' => "//button[@type='submit' and @data-original-title='Search']"]);
-		}
-		else
-		{
-			$I->debug('clearing search filter');
-			$I->click(['xpath' => "//button[@type='button' and @data-original-title='Clear']"]);
-		}
-	}
+    /**
+     * Function to Search For an Item in Joomla! Administrator Lists views
+     *
+     * @param   String  $name  Name of the Item which we need to Search
+     *
+     * @return void
+     */
+    public function searchForItem($name = null)
+    {
+        $I = $this;
+        if($name)
+        {
+            $I->debug("Searching for $name");
+            $I->fillField(['id' => "filter_search"],$name);
+            $I->click(['xpath' => "//button[@type='submit' and @data-original-title='Search']"]);
+        }
+        else
+        {
+            $I->debug('clearing search filter');
+            $I->click(['xpath' => "//button[@type='button' and @data-original-title='Clear']"]);
+        }
+    }
 
-	/**
-	 * Function to Check of the Item Exist in Search Results in Administrator List.
-	 *
-	 * note: on long lists of items the item that your are looking for may not appear in the first page. We recommend
-	 * the usage of searchForItem method before using the current method.
-	 *
-	 * @param   String  $name  Name of the Item which we are Searching For
-	 *
-	 * @return void
-	 */
-	public function checkExistenceOf($name)
-	{
-		$I = $this;
-		$I->debug("Verifying if $name exist in search result");
-		$I->seeElement(['xpath' => "//form[@id='adminForm']/div/table/tbody"]);
-		$I->see($name,['xpath' => "//form[@id='adminForm']/div/table/tbody"]);
-	}
+    /**
+     * Function to Check of the Item Exist in Search Results in Administrator List.
+     *
+     * note: on long lists of items the item that your are looking for may not appear in the first page. We recommend
+     * the usage of searchForItem method before using the current method.
+     *
+     * @param   String  $name  Name of the Item which we are Searching For
+     *
+     * @return void
+     */
+    public function checkExistenceOf($name)
+    {
+        $I = $this;
+        $I->debug("Verifying if $name exist in search result");
+        $I->seeElement(['xpath' => "//form[@id='adminForm']/div/table/tbody"]);
+        $I->see($name,['xpath' => "//form[@id='adminForm']/div/table/tbody"]);
+    }
 
-	/**
-	 * Function to select all the item in the Search results in Administrator List
-	 *
-	 * Note: We recommend use of checkAllResults function only after searchForItem to be sure you are selecting only the desired result set
-	 *
-	 * @return void
-	 */
-	public function checkAllResults()
-	{
-		$I = $this;
-		$this->debug("Selecting Checkall button");
-		$I->click(['xpath' => "//thead//input[@name='checkall-toggle' or @name='toggle']"]);
-	}
+    /**
+     * Function to select all the item in the Search results in Administrator List
+     *
+     * Note: We recommend use of checkAllResults function only after searchForItem to be sure you are selecting only the desired result set
+     *
+     * @return void
+     */
+    public function checkAllResults()
+    {
+        $I = $this;
+        $this->debug("Selecting Checkall button");
+        $I->click(['xpath' => "//thead//input[@name='checkall-toggle' or @name='toggle']"]);
+    }
 
     /**
      * Function to install a language through the interface


### PR DESCRIPTION
This pull Adds robo.li support. This first robo taks allows to generate documentation automatically using: `vendor/bin/robo generate:api-documentation`

I have moved JoomlaBrowser indentation from TABs into Spaces temporarily, is needed for the automated generation until we fork this tasks https://github.com/Codegyre/Robo/blob/master/src/Task/Development/GenerateMarkdownDoc.php#L390 and we move it to our https://github.com/joomla-projects/robo using Joomla Coding standards (https://github.com/joomla/coding-standards)