### PR TITLE
Fix joomla installation folder removal false positives

### DIFF
--- a/src/JoomlaBrowser.php
+++ b/src/JoomlaBrowser.php
@@ -158,7 +158,7 @@ class JoomlaBrowser extends WebDriver
 
         $this->debug('Removing Installation Folder');
         $I->click(['xpath' => "//input[@value='Remove installation folder']"]);
-        $I->waitForElementVisible(['xpath' => "//input[@value='Installation folder successfully removed']"]);
+        $I->waitForElement(['xpath' => "//input[@value='Installation folder successfully removed']"]);
         $this->debug('Joomla is now installed');
         $I->see('Congratulations! Joomla! is now installed.',['xpath' => '//h3']);
     }


### PR DESCRIPTION
This command was wrong. It was waiting for a visibility change in the element, but the right check is not to check if visibilty is changed but if the element has appeared in the DOM.