### PR TITLE
Add check for Strict standards PHP errors in Warning checker

### DIFF
--- a/src/JoomlaBrowser.php
+++ b/src/JoomlaBrowser.php
@@ -325,6 +325,7 @@ class JoomlaBrowser extends WebDriver
 
         $I->dontSeeInPageSource('Notice:');
         $I->dontSeeInPageSource('Warning:');
+        $I->dontSeeInPageSource('Strict standards:');
     }
 
     /**


### PR DESCRIPTION
It checks for errors like this too:

<img width="796" alt="screen shot 2015-08-03 at 18 03 36" src="https://cloud.githubusercontent.com/assets/1375475/9041597/242e7b58-3a09-11e5-81e5-cf3ad2ec0ba0.png">
