### PR TITLE
Force language change during installation

### DIFF
--- a/src/JoomlaBrowser.php
+++ b/src/JoomlaBrowser.php
@@ -131,6 +131,8 @@ class JoomlaBrowser extends WebDriver
         $I->waitForElement('#jform_language', 10);
 
         $I->debug('I select en-GB as installation language');
+        // Select a random language to force reloading of the lang strings after selecting English
+        $I->selectOptionInChosen('#jform_language', 'Danish (DK)');
         $I->selectOptionInChosen('#jform_language', 'English (United Kingdom)');
         $this->debug('I fill Site Name');
         $I->fillField(['id' => 'jform_site_name'], 'Joomla CMS test');


### PR DESCRIPTION
When English is already selected, sometimes the installation page text still appears in the browser's language instead of the one selected. The installation will fail because the "Next" selector will not be found.

This PR fixes it by first selecting a random language to force refreshing of the lang strings when English is selected