### PR TITLE
PR fixes the "Alert window" problem on Windows…

### DIFF
--- a/src/JoomlaBrowser.php
+++ b/src/JoomlaBrowser.php
@@ -133,7 +133,9 @@ class JoomlaBrowser extends WebDriver
         $I->debug('I select en-GB as installation language');
         // Select a random language to force reloading of the lang strings after selecting English
         $I->selectOptionInChosen('#jform_language', 'Danish (DK)');
+        $I->waitForText('Generel konfiguration', 10, 'h3');
         $I->selectOptionInChosen('#jform_language', 'English (United Kingdom)');
+        $I->waitForText('Main Configuration', 10, 'h3');
         $this->debug('I fill Site Name');
         $I->fillField(['id' => 'jform_site_name'], 'Joomla CMS test');
         $this->debug('I fill Site Description');

--- a/src/JoomlaBrowser.php
+++ b/src/JoomlaBrowser.php
@@ -129,11 +129,15 @@ class JoomlaBrowser extends WebDriver
         // I Wait for the text Main Configuration, meaning that the page is loaded
         $this->debug('I wait for Main Configuration');
         $I->waitForElement('#jform_language', 10);
-
-        $I->debug('I select en-GB as installation language');
+        // Wait for chosen to render the field
+        $I->wait(1);
+        $I->debug('I select dk-DK as installation language');
         // Select a random language to force reloading of the lang strings after selecting English
         $I->selectOptionInChosen('#jform_language', 'Danish (DK)');
         $I->waitForText('Generel konfiguration', 10, 'h3');
+        // Wait for chosen to render the field
+        $I->wait(1);
+        $I->debug('I select en-GB as installation language');
         $I->selectOptionInChosen('#jform_language', 'English (United Kingdom)');
         $I->waitForText('Main Configuration', 10, 'h3');
         $this->debug('I fill Site Name');


### PR DESCRIPTION
…when the languages are changed in the installation process.

We wait until the language changing request is fully executed, then the problem with the alert window does not occur any more.

**How to test**

Just run the installation test on a Windows machine and check whether the test passes successfully.