### PR TITLE
wait for the folder to be deleted and then go further!

### DIFF
--- a/src/JoomlaBrowser.php
+++ b/src/JoomlaBrowser.php
@@ -204,18 +204,9 @@ class JoomlaBrowser extends WebDriver
 
         $this->debug('Removing Installation Folder');
         $I->click(['xpath' => "//input[@value='Remove installation folder']"]);
+
         $I->debug('I wait for Removing Installation Folder button to become disabled');
-        // @todo https://github.com/joomla-projects/joomla-browser/issues/45
-        $I->wait(2);
-        /*
-        $I->waitForElementChange(
-            ['xpath' => "//input[@name='instDefault']"],
-            function(WebDriverElement $el) {
-                return !$el->isEnabled();
-            },
-            60
-        );
-        */
+        $I->waitForJS("return jQuery('form#adminForm input[name=instDefault]').attr('disabled') == 'disabled';", 60);
 
         $I->debug('Joomla is now installed');
         $I->see('Congratulations! Joomla! is now installed.',['xpath' => '//h3']);


### PR DESCRIPTION
This should fix 
https://github.com/joomla-projects/joomla-browser/issues/45
https://github.com/joomla-projects/joomla-browser/pull/51

I couldn't make it work with waitForElementChange, but this solution is basically the same with JS. The js is executed until the condition is met(the field becomes disabled). If this happens within 60s, then we go further...