### PR TITLE
Avoid false positives in Administrator Login

### DIFF
--- a/src/JoomlaBrowser.php
+++ b/src/JoomlaBrowser.php
@@ -50,7 +50,8 @@ class JoomlaBrowser extends WebDriver
 
         $this->debug('I open Joomla Administrator Login Page');
         $I->amOnPage('/administrator/index.php');
-        $this->debug('Fill Username Text Field');
+		$I->waitForElement(['id' => 'mod-login-username'], 60);
+		$this->debug('Fill Username Text Field');
         $I->fillField(['id' => 'mod-login-username'], $user);
         $this->debug('Fill Password Text Field');
         $I->fillField(['id' => 'mod-login-password'], $password);


### PR DESCRIPTION
There was a missing `wait` that causes sometime false positives.