### PR TITLE
Add compatibility with Joomla 3.5.1 changed uninstalling method

### DIFF
--- a/src/JoomlaBrowser.php
+++ b/src/JoomlaBrowser.php
@@ -558,6 +558,7 @@ class JoomlaBrowser extends WebDriver
 		$I->waitForElement(['id' => 'manageList'],'30');
 		$I->click(['xpath' => "//input[@id='cb0']"]);
 		$I->click(['xpath' => "//div[@id='toolbar-delete']/button"]);
+		$I->acceptPopup();
 		$I->waitForText('was successful','30', ['id' => 'system-message-container']);
 		$I->see('was successful', ['id' => 'system-message-container']);
 		$I->searchForItem($extensionName);


### PR DESCRIPTION
Uninstall method in Joomla 3.5.x has a popup when uninstalling any extension. This popup was not in 3.4.x series:


![screen shot 2016-05-04 at 12 08 07](https://cloud.githubusercontent.com/assets/1375475/15011219/e3f1d1b4-11f0-11e6-9ae4-23e44692e16c.png)

After this get merged we should release Joomla-browser 3.5.1.0