### PR TITLE
Limited multilanguage selector in installer for v.3.6.0 compatibility

### DIFF
--- a/src/JoomlaBrowser.php
+++ b/src/JoomlaBrowser.php
@@ -268,7 +268,7 @@ class JoomlaBrowser extends WebDriver
 		foreach ($languages as $language)
 		{
 			$I->debug('I mark the checkbox of the language: ' . $language);
-			$I->click(['xpath' => "//label[contains(text()[normalize-space()], '$language')]/input"]);
+			$I->click(['xpath' => "//label[contains(text()[normalize-space()], '$language')]"]);
 		}
 
 		$I->click(['link' => 'Next']);


### PR DESCRIPTION
The new installer does not include the `<input>` tag into the `<label>` tag but it's in another structure now.

Therefore I'm limiting the click to the `<label>` tag which works correctly as long as it's linked to the `<input>` tag via a `for` attribute
