### PR TITLE
update selenium_v3.0.1.2

### DIFF
--- a/src/JoomlaBrowser.php
+++ b/src/JoomlaBrowser.php
@@ -153,14 +153,14 @@ class JoomlaBrowser extends WebDriver
 		$I->debug('I select dk-DK as installation language');
 
 		// Select a random language to force reloading of the lang strings after selecting English
-		$I->selectOptionInChosen('#jform_language', 'Danish (DK)');
-		$I->waitForText('Generel konfiguration', 60, 'h3');
+		$I->selectOptionInChosenWithTextField('#jform_language', 'Spanish (Español)');
+		$I->waitForText('Configuración principal', 60, 'h3');
 
 		// Wait for chosen to render the field
 		$I->debug('I select en-GB as installation language');
 		$I->debug('Wait for chosen to render the Languages list field');
 		$I->wait(2);
-		$I->selectOptionInChosen('#jform_language', 'English (United Kingdom)');
+		$I->selectOptionInChosenWithTextField('#jform_language', 'English (United Kingdom)');
 		$I->waitForText('Main Configuration', 60, 'h3');
 		$this->debug('I fill Site Name');
 		$I->fillField(['id' => 'jform_site_name'], 'Joomla CMS test');
@@ -309,7 +309,8 @@ class JoomlaBrowser extends WebDriver
 		$this->debug('I wait for error reporting dropdown');
 		$I->selectOptionInChosen('Error Reporting', 'Development');
 		$this->debug('I click on save');
-		$this->clickToolbarButton('save');
+		//$this->clickToolbarButton('save');
+		$I->click(['xpath' => "//div[@id='toolbar-apply']//button"]);
 		$this->debug('I wait for global configuration being saved');
 		$I->waitForText('Global Configuration', 60, ['css' => '.page-title']);
 		$I->see('Configuration successfully saved.', ['id' => 'system-message-container']);
@@ -438,7 +439,7 @@ class JoomlaBrowser extends WebDriver
 		$I->click("//fieldset[@id='$radioId']/label[contains(normalize-space(string(.)), '$option')]");
 	}
 
-	/**
+/**
 	 * Selects an option in a Chosen Selector based on its label
 	 *
 	 * @param   string  $label   The text in the <label> with for attribute that links to the <select> element
@@ -456,6 +457,29 @@ class JoomlaBrowser extends WebDriver
 		$I->click(['xpath' => "//div[@id='$chosenSelectID']/a/div/b"]);
 		$this->debug("I select $option");
 		$I->click(['xpath' => "//div[@id='$chosenSelectID']//li[text()='$option']"]);
+		// Gives time to chosen to close
+		$I->wait(1);
+	}
+
+	/**
+	 * Selects an option in a Chosen Selector based on its label with filling the textfield
+	 *
+	 * @param   string  $label   The text in the <label> with for attribute that links to the <select> element
+	 * @param   string  $option  The text in the <option> to be selected in the chosen selector
+	 *
+	 * @return void
+	 */
+	public function selectOptionInChosenWithTextField($label, $option)
+	{
+		$select = $this->findField($label);
+		$selectID = $select->getAttribute('id');
+		$chosenSelectID = $selectID . '_chzn';
+		$I = $this;
+		$this->debug("I open the $label chosen selector");
+		$I->click(['css' => 'div#'.$chosenSelectID]);
+		$this->debug("I select $option");
+		$I->fillField(['xpath' => "//div[@id='$chosenSelectID']/div/div/input"], $option);
+		$I->click(['xpath' => "//div[@id='$chosenSelectID']/div/ul/li[1]"]);
 
 		// Gives time to chosen to close
 		$I->wait(1);

--- a/src/JoomlaBrowser.php
+++ b/src/JoomlaBrowser.php
@@ -309,7 +309,6 @@ class JoomlaBrowser extends WebDriver
 		$this->debug('I wait for error reporting dropdown');
 		$I->selectOptionInChosen('Error Reporting', 'Development');
 		$this->debug('I click on save');
-		//$this->clickToolbarButton('save');
 		$I->click(['xpath' => "//div[@id='toolbar-apply']//button"]);
 		$this->debug('I wait for global configuration being saved');
 		$I->waitForText('Global Configuration', 60, ['css' => '.page-title']);
@@ -439,7 +438,7 @@ class JoomlaBrowser extends WebDriver
 		$I->click("//fieldset[@id='$radioId']/label[contains(normalize-space(string(.)), '$option')]");
 	}
 
-/**
+	/**
 	 * Selects an option in a Chosen Selector based on its label
 	 *
 	 * @param   string  $label   The text in the <label> with for attribute that links to the <select> element
@@ -457,6 +456,7 @@ class JoomlaBrowser extends WebDriver
 		$I->click(['xpath' => "//div[@id='$chosenSelectID']/a/div/b"]);
 		$this->debug("I select $option");
 		$I->click(['xpath' => "//div[@id='$chosenSelectID']//li[text()='$option']"]);
+
 		// Gives time to chosen to close
 		$I->wait(1);
 	}
@@ -476,7 +476,7 @@ class JoomlaBrowser extends WebDriver
 		$chosenSelectID = $selectID . '_chzn';
 		$I = $this;
 		$this->debug("I open the $label chosen selector");
-		$I->click(['css' => 'div#'.$chosenSelectID]);
+		$I->click(['css' => 'div#' . $chosenSelectID]);
 		$this->debug("I select $option");
 		$I->fillField(['xpath' => "//div[@id='$chosenSelectID']/div/div/input"], $option);
 		$I->click(['xpath' => "//div[@id='$chosenSelectID']/div/ul/li[1]"]);


### PR DESCRIPTION
I changed the random language to Spanish. Reason: If you change it to Danish the language in the installation dialog is not changed anymore. So the test failed because the text 'Generel konfiguration' could not be found.
Then I changed the syntax for clicking the toolbar button.
At last I add the method selectOptionInChosenWithTextField. This method fill the text field if a chosen field has one. With this change for me the test runs in Firefox. 