### PR TITLE
Adding Support of Custom Template Locators

### DIFF
--- a/src/JoomlaBrowser.php
+++ b/src/JoomlaBrowser.php
@@ -7,7 +7,7 @@
  */
 
 namespace Codeception\Module;
-
+use Joomla\Browser\Locators\Locators;
 use Codeception\Module\WebDriver;
 require_once('locator/Locators.php');
 const TIMEOUT = 60;
@@ -40,7 +40,7 @@ class JoomlaBrowser extends WebDriver
 		'language'
 	);
 
-	protected $locatorObject;
+	protected $locator;
 
 	/**
 	 * Function to instantiate the Locator Class, In case of a custom Template,
@@ -62,15 +62,15 @@ class JoomlaBrowser extends WebDriver
 	{
 		if (empty($this->config['locator class']))
 		{
-			$this->locatorObject = new \Locators();
+			$this->locator = new Locators;
 		}
 		else
 		{
 			$temp = $this->config['locator class'];
-			$this->locatorObject = new $temp;
+			$this->locator = new $temp;
 		}
 
-		return $this->locatorObject;
+		return $this->locator;
 	}
 
 	/**
@@ -98,18 +98,18 @@ class JoomlaBrowser extends WebDriver
 		}
 
 		$this->debug('I open Joomla Administrator Login Page');
-		$I->amOnPage($locator::$adminLoginPageUrl);
-		$I->waitForElement($locator::$adminLoginUserName, TIMEOUT);
+		$I->amOnPage($locator->adminLoginPageUrl);
+		$I->waitForElement($locator->adminLoginUserName, TIMEOUT);
 		$this->debug('Fill Username Text Field');
-		$I->fillField($locator::$adminLoginUserName, $user);
+		$I->fillField($locator->adminLoginUserName, $user);
 		$this->debug('Fill Password Text Field');
-		$I->fillField($locator::$adminLoginPassword, $password);
+		$I->fillField($locator->adminLoginPassword, $password);
 
 		// @todo: update login button in joomla login screen to make this xPath more friendly
 		$this->debug('I click Login button');
-		$I->click($locator::$adminLoginButton);
+		$I->click($locator->adminLoginButton);
 		$this->debug('I wait to see Administrator Control Panel');
-		$I->waitForText('Control Panel', 4, $locator::$controlPanelLocator);
+		$I->waitForText('Control Panel', 4, $locator->controlPanelLocator);
 	}
 
 	/**
@@ -123,7 +123,7 @@ class JoomlaBrowser extends WebDriver
 	public function doFrontEndLogin($user = null, $password = null)
 	{
 		$I = $this;
-		$locatorObject = $this->instantiateLocator();
+		$locator = $this->instantiateLocator();
 
 		if (is_null($user))
 		{
@@ -136,18 +136,18 @@ class JoomlaBrowser extends WebDriver
 		}
 
 		$this->debug('I open Joomla Frontend Login Page');
-		$I->amOnPage($locatorObject::$frontEndLoginUrl);
+		$I->amOnPage($locator->frontEndLoginUrl);
 		$this->debug('Fill Username Text Field');
-		$I->fillField($locatorObject::$loginUserName, $user);
+		$I->fillField($locator->loginUserName, $user);
 		$this->debug('Fill Password Text Field');
-		$I->fillField($locatorObject::$loginPassword, $password);
+		$I->fillField($locator->loginPassword, $password);
 
 		// @todo: update login button in joomla login screen to make this xPath more friendly
 		$this->debug('I click Login button');
-		$I->click($locatorObject::$loginButton);
+		$I->click($locator->loginButton);
 		$this->debug('I wait to see Frontend Member Profile Form with the Logout button in the module');
 
-		$I->waitForElement($locatorObject::$frontEndLoginSuccess, TIMEOUT);
+		$I->waitForElement($locator->frontEndLoginSuccess, TIMEOUT);
 	}
 
 	/**
@@ -160,12 +160,12 @@ class JoomlaBrowser extends WebDriver
 		$I = $this;
 		$locator = $this->instantiateLocator();
 		$this->debug('I open Joomla Frontend Login Page');
-		$I->amOnPage($locator::$frontEndLoginUrl);
+		$I->amOnPage($locator->frontEndLoginUrl);
 		$this->debug('I click Logout button');
-		$I->click($locator::$frontEndLogoutButton);
+		$I->click($locator->frontEndLogoutButton);
 		$this->debug('I wait to see Login form');
-		$I->waitForElement($locator::$frontEndLoginForm, 30);
-		$I->seeElement($locator::$frontEndLoginForm);
+		$I->waitForElement($locator->frontEndLoginForm, 30);
+		$I->seeElement($locator->frontEndLoginForm);
 	}
 
 	/**

--- a/src/JoomlaBrowser.php
+++ b/src/JoomlaBrowser.php
@@ -38,6 +38,38 @@ class JoomlaBrowser extends WebDriver
 		'language'
 	);
 
+	protected $locatorObject;
+
+	/**
+	 * Function to instantiate the Locator Class, In case of a custom Template,
+	 * path to the custom Template Locator could be passed in Acceptance.suite.yml file
+	 *
+	 * for example: If the Class is present at _support/Page/Acceptance folder, simple add a new Parameter in acceptance.suite.yml file
+	 *
+	 * locator class: 'Page\Acceptance\Bootstrap2TemplateLocators'
+	 *
+	 * Locator could be set to null like this
+	 *
+	 * locator class: null
+	 *
+	 * When set to null, Joomla Browser will use the custom Locators present inside Locators.php
+	 *
+	 * @return \Locators
+	 */
+	public function instantiateLocator()
+	{
+		if (!(isset($this->config['locator class'])) || is_null($this->config['locator class']))
+		{
+			$this->locatorObject = new \Locators();
+		}
+		else{
+			$temp = $this->config['locator class'];
+			$this->locatorObject = new $temp;
+		}
+
+		return $this->locatorObject;
+	}
+
 	/**
 	 * Function to Do Admin Login In Joomla!
 	 *
@@ -49,6 +81,8 @@ class JoomlaBrowser extends WebDriver
 	public function doAdministratorLogin($user = null, $password = null)
 	{
 		$I = $this;
+		$locator = $this->instantiateLocator();
+
 
 		if (is_null($user))
 		{
@@ -61,18 +95,18 @@ class JoomlaBrowser extends WebDriver
 		}
 
 		$this->debug('I open Joomla Administrator Login Page');
-		$I->amOnPage('/administrator/index.php');
-		$I->waitForElement(['id' => 'mod-login-username'], 60);
+		$I->amOnPage($locator::$adminLoginPageUrl);
+		$I->waitForElement($locator::$adminLoginUserName, 60);
 		$this->debug('Fill Username Text Field');
-		$I->fillField(['id' => 'mod-login-username'], $user);
+		$I->fillField($locator::$adminLoginUserName, $user);
 		$this->debug('Fill Password Text Field');
-		$I->fillField(['id' => 'mod-login-password'], $password);
+		$I->fillField($locator::$adminLoginPassword, $password);
 
 		// @todo: update login button in joomla login screen to make this xPath more friendly
 		$this->debug('I click Login button');
-		$I->click(['xpath' => "//button[contains(normalize-space(), 'Log in')]"]);
+		$I->click($locator::$adminLoginButton);
 		$this->debug('I wait to see Administrator Control Panel');
-		$I->waitForText('Control Panel', 4, ['css' => 'h1.page-title']);
+		$I->waitForText('Control Panel', 4, $locator::$controlPanelLocator);
 	}
 
 	/**
@@ -86,6 +120,7 @@ class JoomlaBrowser extends WebDriver
 	public function doFrontEndLogin($user = null, $password = null)
 	{
 		$I = $this;
+		$locatorObject = $this->instantiateLocator();
 
 		if (is_null($user))
 		{
@@ -98,17 +133,18 @@ class JoomlaBrowser extends WebDriver
 		}
 
 		$this->debug('I open Joomla Frontend Login Page');
-		$I->amOnPage('/index.php?option=com_users&view=login');
+		$I->amOnPage($locatorObject::$frontEndLoginUrl);
 		$this->debug('Fill Username Text Field');
-		$I->fillField(['id' => 'username'], $user);
+		$I->fillField($locatorObject::$loginUserName, $user);
 		$this->debug('Fill Password Text Field');
-		$I->fillField(['id' => 'password'], $password);
+		$I->fillField($locatorObject::$loginPassword, $password);
 
 		// @todo: update login button in joomla login screen to make this xPath more friendly
 		$this->debug('I click Login button');
-		$I->click(['xpath' => "//div[@class='login']/form/fieldset/div[4]/div/button"]);
+		$I->click($locatorObject::$loginButton);
 		$this->debug('I wait to see Frontend Member Profile Form with the Logout button in the module');
-		$I->waitForElement(['xpath' => "//form[@id='login-form']/div[@class='logout-button']"], 60);
+
+		$I->waitForElement($locatorObject::$frontEndLoginSuccess, 60);
 	}
 
 	/**
@@ -119,13 +155,14 @@ class JoomlaBrowser extends WebDriver
 	public function doFrontendLogout()
 	{
 		$I = $this;
+		$locator = $this->instantiateLocator();
 		$this->debug('I open Joomla Frontend Login Page');
-		$I->amOnPage('/index.php?option=com_users&view=login');
+		$I->amOnPage($locator::$frontEndLoginUrl);
 		$this->debug('I click Logout button');
-		$I->click(['xpath' => "//div[@class='logout']//button[contains(text(), 'Log out')]"]);
+		$I->click($locator::$frontEndLogoutButton);
 		$this->debug('I wait to see Login form');
-		$I->waitForElement(['xpath' => "//div[@class='login']//button[contains(text(), 'Log in')]"], 30);
-		$I->seeElement(['xpath' => "//div[@class='login']//button[contains(text(), 'Log in')]"]);
+		$I->waitForElement($locator::$frontEndLoginForm, 30);
+		$I->seeElement($locator::$frontEndLoginForm);
 	}
 
 	/**

--- a/src/JoomlaBrowser.php
+++ b/src/JoomlaBrowser.php
@@ -7,8 +7,10 @@
  */
 
 namespace Codeception\Module;
+
 use Codeception\Module\Locators\Locators;
 use Codeception\Module\WebDriver;
+
 const TIMEOUT = 60;
 
 /**
@@ -21,7 +23,8 @@ class JoomlaBrowser extends WebDriver
 	/**
 	 * The module required fields, to be set in the suite .yml configuration file.
 	 *
-	 * @var array
+	 * @var     array
+	 * @since   3.0.0
 	 */
 	protected $requiredFields = array(
 		'url',
@@ -39,7 +42,31 @@ class JoomlaBrowser extends WebDriver
 		'language'
 	);
 
+	/**
+	 * The locator
+	 *
+	 * @var     Codeception\Module\Locators\Locators
+	 * @since   3.7.4.2
+	 */
 	protected $locator;
+
+	/**
+	 * Module constructor.
+	 *
+	 * Requires module container (to provide access between modules of suite) and config.
+	 *
+	 * @param   ModuleContainer  $moduleContainer  The module container
+	 * @param   array            $config           The optional config
+	 *
+	 * @since   3.7.4.2
+	 */
+	public function __construct(ModuleContainer $moduleContainer, $config = null)
+	{
+		parent::__construct($moduleContainer, $config);
+
+		// Instantiate the locator
+		$this->instantiateLocator();
+	}
 
 	/**
 	 * Function to instantiate the Locator Class, In case of a custom Template,
@@ -55,21 +82,21 @@ class JoomlaBrowser extends WebDriver
 	 *
 	 * When set to null, Joomla Browser will use the custom Locators present inside Locators.php
 	 *
-	 * @return \Locators
+	 * @return  void
+	 *
+	 * @since   3.0.0
 	 */
-	public function instantiateLocator()
+	protected function instantiateLocator()
 	{
 		if (empty($this->config['locator class']))
 		{
 			$this->locator = new Locators;
-		}
-		else
-		{
-			$temp = $this->config['locator class'];
-			$this->locator = new $temp;
+
+			return;
 		}
 
-		return $this->locator;
+		$class         = $this->config['locator class'];
+		$this->locator = new $class;
 	}
 
 	/**
@@ -79,12 +106,10 @@ class JoomlaBrowser extends WebDriver
 	 * @param   string|null  $password  Optional password. If not passed the one in acceptance.suite.yml will be used
 	 *
 	 * @return  void
+	 * @since   3.0.0
 	 */
 	public function doAdministratorLogin($user = null, $password = null)
 	{
-		$I = $this;
-		$locator = $this->instantiateLocator();
-
 		if (is_null($user))
 		{
 			$user = $this->config['username'];
@@ -96,18 +121,18 @@ class JoomlaBrowser extends WebDriver
 		}
 
 		$this->debug('I open Joomla Administrator Login Page');
-		$I->amOnPage($locator->adminLoginPageUrl);
-		$I->waitForElement($locator->adminLoginUserName, TIMEOUT);
+		$this->amOnPage($this->locator->adminLoginPageUrl);
+		$this->waitForElement($this->locator->adminLoginUserName, TIMEOUT);
 		$this->debug('Fill Username Text Field');
-		$I->fillField($locator->adminLoginUserName, $user);
+		$this->fillField($this->locator->adminLoginUserName, $user);
 		$this->debug('Fill Password Text Field');
-		$I->fillField($locator->adminLoginPassword, $password);
+		$this->fillField($this->locator->adminLoginPassword, $password);
 
 		// @todo: update login button in joomla login screen to make this xPath more friendly
 		$this->debug('I click Login button');
-		$I->click($locator->adminLoginButton);
+		$this->click($this->locator->adminLoginButton);
 		$this->debug('I wait to see Administrator Control Panel');
-		$I->waitForText('Control Panel', 4, $locator->controlPanelLocator);
+		$this->waitForText('Control Panel', 4, $this->locator->controlPanelLocator);
 	}
 
 	/**
@@ -117,12 +142,10 @@ class JoomlaBrowser extends WebDriver
 	 * @param   string|null  $password  Optional password. If not passed the one in acceptance.suite.yml will be used
 	 *
 	 * @return  void
+	 * @since   3.0.0
 	 */
 	public function doFrontEndLogin($user = null, $password = null)
 	{
-		$I = $this;
-		$locator = $this->instantiateLocator();
-
 		if (is_null($user))
 		{
 			$user = $this->config['username'];
@@ -134,149 +157,145 @@ class JoomlaBrowser extends WebDriver
 		}
 
 		$this->debug('I open Joomla Frontend Login Page');
-		$I->amOnPage($locator->frontEndLoginUrl);
+		$this->amOnPage($this->locator->frontEndLoginUrl);
 		$this->debug('Fill Username Text Field');
-		$I->fillField($locator->loginUserName, $user);
+		$this->fillField($this->locator->loginUserName, $user);
 		$this->debug('Fill Password Text Field');
-		$I->fillField($locator->loginPassword, $password);
+		$this->fillField($this->locator->loginPassword, $password);
 
 		// @todo: update login button in joomla login screen to make this xPath more friendly
 		$this->debug('I click Login button');
-		$I->click($locator->loginButton);
+		$this->click($this->locator->loginButton);
 		$this->debug('I wait to see Frontend Member Profile Form with the Logout button in the module');
 
-		$I->waitForElement($locator->frontEndLoginSuccess, TIMEOUT);
+		$this->waitForElement($this->locator->frontEndLoginSuccess, TIMEOUT);
 	}
 
 	/**
 	 * Function to Do frontend Logout in Joomla!
 	 *
 	 * @return  void
+	 *
+	 * @since   3.0.0
 	 */
 	public function doFrontendLogout()
 	{
-		$I = $this;
-		$locator = $this->instantiateLocator();
 		$this->debug('I open Joomla Frontend Login Page');
-		$I->amOnPage($locator->frontEndLoginUrl);
+		$this->amOnPage($this->locator->frontEndLoginUrl);
 		$this->debug('I click Logout button');
-		$I->click($locator->frontEndLogoutButton);
+		$this->click($this->locator->frontEndLogoutButton);
 		$this->debug('I wait to see Login form');
-		$I->waitForElement($locator->frontEndLoginForm, 30);
-		$I->seeElement($locator->frontEndLoginForm);
+		$this->waitForElement($this->locator->frontEndLoginForm, 30);
+		$this->seeElement($this->locator->frontEndLoginForm);
 	}
 
 	/**
 	 * Installs Joomla
 	 *
 	 * @return  void
+	 * @since   3.0.0
 	 */
 	public function installJoomla()
 	{
-		$I = $this;
-
-		// Install Joomla CMS');
-
 		$this->debug('I open Joomla Installation Configuration Page');
-		$I->amOnPage('/installation/index.php');
+		$this->amOnPage('/installation/index.php');
 		$this->debug('I check that FTP tab is not present in installation. Otherwise it means that I have not enough '
-			. 'permissions to install joomla and execution will be stoped');
-		$I->dontSeeElement(['id' => 'ftp']);
+		             . 'permissions to install joomla and execution will be stoped');
+		$this->dontSeeElement(['id' => 'ftp']);
 
 		// I Wait for the text Main Configuration, meaning that the page is loaded
 		$this->debug('I wait for Main Configuration');
-		$I->waitForElement('#jform_language', 10);
-		$I->debug('Wait for chosen to render the Languages list field');
-		$I->wait(2);
-		$I->debug('I select dk-DK as installation language');
+		$this->waitForElement('#jform_language', 10);
+		$this->debug('Wait for chosen to render the Languages list field');
+		$this->wait(2);
+		$this->debug('I select dk-DK as installation language');
 
 		// Select a random language to force reloading of the lang strings after selecting English
-		$I->selectOptionInChosenWithTextField('#jform_language', 'Spanish (Español)');
-		$I->waitForText('Configuración principal', TIMEOUT, 'h3');
+		$this->selectOptionInChosenWithTextField('#jform_language', 'Spanish (Español)');
+		$this->waitForText('Configuración principal', TIMEOUT, 'h3');
 
 		// Wait for chosen to render the field
-		$I->debug('I select en-GB as installation language');
-		$I->debug('Wait for chosen to render the Languages list field');
-		$I->wait(2);
-		$I->selectOptionInChosenWithTextField('#jform_language', 'English (United Kingdom)');
-		$I->waitForText('Main Configuration', TIMEOUT, 'h3');
+		$this->debug('I select en-GB as installation language');
+		$this->debug('Wait for chosen to render the Languages list field');
+		$this->wait(2);
+		$this->selectOptionInChosenWithTextField('#jform_language', 'English (United Kingdom)');
+		$this->waitForText('Main Configuration', TIMEOUT, 'h3');
 		$this->debug('I fill Site Name');
-		$I->fillField(['id' => 'jform_site_name'], 'Joomla CMS test');
+		$this->fillField(['id' => 'jform_site_name'], 'Joomla CMS test');
 		$this->debug('I fill Site Description');
-		$I->fillField(['id' => 'jform_site_metadesc'], 'Site for testing Joomla CMS');
+		$this->fillField(['id' => 'jform_site_metadesc'], 'Site for testing Joomla CMS');
 
 		// I get the configuration from acceptance.suite.yml (see: tests/_support/acceptancehelper.php)
 		$this->debug('I fill Admin Email');
-		$I->fillField(['id' => 'jform_admin_email'], $this->config['admin email']);
+		$this->fillField(['id' => 'jform_admin_email'], $this->config['admin email']);
 		$this->debug('I fill Admin Username');
-		$I->fillField(['id' => 'jform_admin_user'], $this->config['username']);
+		$this->fillField(['id' => 'jform_admin_user'], $this->config['username']);
 		$this->debug('I fill Admin Password');
-		$I->fillField(['id' => 'jform_admin_password'], $this->config['password']);
+		$this->fillField(['id' => 'jform_admin_password'], $this->config['password']);
 		$this->debug('I fill Admin Password Confirmation');
-		$I->fillField(['id' => 'jform_admin_password2'], $this->config['password']);
+		$this->fillField(['id' => 'jform_admin_password2'], $this->config['password']);
 		$this->debug('I click Site Offline: no');
 
 		// ['No Site Offline']
-		$I->click(['xpath' => "//fieldset[@id='jform_site_offline']/label[@for='jform_site_offline1']"]);
+		$this->click(['xpath' => "//fieldset[@id='jform_site_offline']/label[@for='jform_site_offline1']"]);
 		$this->debug('I click Next');
-		$I->click(['link' => 'Next']);
+		$this->click(['link' => 'Next']);
 
 		$this->debug('I Fill the form for creating the Joomla site Database');
-		$I->waitForText('Database Configuration', TIMEOUT, ['css' => 'h3']);
+		$this->waitForText('Database Configuration', TIMEOUT, ['css' => 'h3']);
 
 		$this->debug('I select MySQLi');
-		$I->selectOption(['id' => 'jform_db_type'], $this->config['database type']);
+		$this->selectOption(['id' => 'jform_db_type'], $this->config['database type']);
 		$this->debug('I fill Database Host');
-		$I->fillField(['id' => 'jform_db_host'], $this->config['database host']);
+		$this->fillField(['id' => 'jform_db_host'], $this->config['database host']);
 		$this->debug('I fill Database User');
-		$I->fillField(['id' => 'jform_db_user'], $this->config['database user']);
+		$this->fillField(['id' => 'jform_db_user'], $this->config['database user']);
 		$this->debug('I fill Database Password');
-		$I->fillField(['id' => 'jform_db_pass'], $this->config['database password']);
+		$this->fillField(['id' => 'jform_db_pass'], $this->config['database password']);
 		$this->debug('I fill Database Name');
-		$I->fillField(['id' => 'jform_db_name'], $this->config['database name']);
+		$this->fillField(['id' => 'jform_db_name'], $this->config['database name']);
 		$this->debug('I fill Database Prefix');
-		$I->fillField(['id' => 'jform_db_prefix'], $this->config['database prefix']);
+		$this->fillField(['id' => 'jform_db_prefix'], $this->config['database prefix']);
 		$this->debug('I click Remove Old Database ');
-		$I->selectOptionInRadioField('Old Database Process', 'Remove');
+		$this->selectOptionInRadioField('Old Database Process', 'Remove');
 		$this->debug('I click Next');
-		$I->click(['link' => 'Next']);
+		$this->click(['link' => 'Next']);
 		$this->debug('I wait Joomla to remove the old database if exist');
-		$I->wait(1);
-		$I->waitForElementVisible(['id' => 'jform_sample_file-lbl'], 30);
+		$this->wait(1);
+		$this->waitForElementVisible(['id' => 'jform_sample_file-lbl'], 30);
 
 		$this->debug('I install joomla with or without sample data');
-		$I->waitForText('Finalisation', TIMEOUT, ['xpath' => '//h3']);
+		$this->waitForText('Finalisation', TIMEOUT, ['xpath' => '//h3']);
 
 		// @todo: installation of sample data needs to be created
 
 		// No sample data
-		$I->selectOption(['id' => 'jform_sample_file'], ['id' => 'jform_sample_file0']);
-		$I->click(['link' => 'Install']);
+		$this->selectOption(['id' => 'jform_sample_file'], ['id' => 'jform_sample_file0']);
+		$this->click(['link' => 'Install']);
 
 		// Wait while Joomla gets installed
 		$this->debug('I wait for Joomla being installed');
-		$I->waitForText('Congratulations! Joomla! is now installed.', TIMEOUT, ['xpath' => '//h3']);
+		$this->waitForText('Congratulations! Joomla! is now installed.', TIMEOUT, ['xpath' => '//h3']);
 	}
 
 	/**
 	 * Install Joomla removing the Installation folder at the end of the execution
 	 *
 	 * @return  void
+	 * @since   3.0.0
 	 */
 	public function installJoomlaRemovingInstallationFolder()
 	{
-		$I = $this;
-
-		$I->installJoomla();
+		$this->installJoomla();
 
 		$this->debug('Removing Installation Folder');
-		$I->click(['xpath' => "//input[@value='Remove installation folder']"]);
+		$this->click(['xpath' => "//input[@value='Remove installation folder']"]);
 
-		$I->debug('I wait for Removing Installation Folder button to become disabled');
-		$I->waitForJS("return jQuery('form#adminForm input[name=instDefault]').attr('disabled') == 'disabled';", TIMEOUT);
+		$this->debug('I wait for Removing Installation Folder button to become disabled');
+		$this->waitForJS("return jQuery('form#adminForm input[name=instDefault]').attr('disabled') == 'disabled';", TIMEOUT);
 
-		$I->debug('Joomla is now installed');
-		$I->see('Congratulations! Joomla! is now installed.', ['xpath' => '//h3']);
+		$this->debug('Joomla is now installed');
+		$this->see('Congratulations! Joomla! is now installed.', ['xpath' => '//h3']);
 	}
 
 	/**
@@ -284,9 +303,10 @@ class JoomlaBrowser extends WebDriver
 	 *
 	 * @param   array  $languages  Array containing the language names to be installed
 	 *
-	 * @example: $I->installJoomlaMultilingualSite(['Spanish', 'French']);
+	 * @example: $this->installJoomlaMultilingualSite(['Spanish', 'French']);
 	 *
 	 * @return  void
+	 * @since   3.0.0
 	 */
 	public function installJoomlaMultilingualSite($languages = array())
 	{
@@ -296,61 +316,60 @@ class JoomlaBrowser extends WebDriver
 			$languages[] = 'French';
 		}
 
-		$I = $this;
-
-		$I->installJoomla();
+		$this->installJoomla();
 
 		$this->debug('I go to Install Languages page');
-		$I->click(['id' => 'instLangs']);
-		$I->waitForText('Install Language packages', TIMEOUT, ['xpath' => '//h3']);
+		$this->click(['id' => 'instLangs']);
+		$this->waitForText('Install Language packages', TIMEOUT, ['xpath' => '//h3']);
 
 		foreach ($languages as $language)
 		{
-			$I->debug('I mark the checkbox of the language: ' . $language);
-			$I->click(['xpath' => "//label[contains(text()[normalize-space()], '$language')]"]);
+			$this->debug('I mark the checkbox of the language: ' . $language);
+			$this->click(['xpath' => "//label[contains(text()[normalize-space()], '$language')]"]);
 		}
 
-		$I->click(['link' => 'Next']);
-		$I->waitForText('Multilingual', TIMEOUT, ['xpath' => '//h3']);
-		$I->selectOptionInRadioField('Activate the multilingual feature', 'Yes');
-		$I->waitForElementVisible(['id' => 'jform_activatePluginLanguageCode-lbl']);
-		$I->selectOptionInRadioField('Install localised content', 'Yes');
-		$I->selectOptionInRadioField('Enable the language code plugin', 'Yes');
-		$I->click(['link' => 'Next']);
+		$this->click(['link' => 'Next']);
+		$this->waitForText('Multilingual', TIMEOUT, ['xpath' => '//h3']);
+		$this->selectOptionInRadioField('Activate the multilingual feature', 'Yes');
+		$this->waitForElementVisible(['id' => 'jform_activatePluginLanguageCode-lbl']);
+		$this->selectOptionInRadioField('Install localised content', 'Yes');
+		$this->selectOptionInRadioField('Enable the language code plugin', 'Yes');
+		$this->click(['link' => 'Next']);
 
-		$I->waitForText('Congratulations! Joomla! is now installed.', TIMEOUT, ['xpath' => '//h3']);
+		$this->waitForText('Congratulations! Joomla! is now installed.', TIMEOUT, ['xpath' => '//h3']);
 		$this->debug('Removing Installation Folder');
-		$I->click(['xpath' => "//input[@value='Remove installation folder']"]);
+		$this->click(['xpath' => "//input[@value='Remove installation folder']"]);
 
 		// @todo https://github.com/joomla-projects/joomla-browser/issues/45
-		$I->wait(2);
+		$this->wait(2);
 
 		$this->debug('Joomla is now installed');
-		$I->see('Congratulations! Joomla! is now installed.', ['xpath' => '//h3']);
+		$this->see('Congratulations! Joomla! is now installed.', ['xpath' => '//h3']);
 	}
 
 	/**
-	 * Sets in Adminitrator->Global Configuration the Error reporting to Development
+	 * Sets in Administrator->Global Configuration the Error reporting to Development
 	 * {@internal doAdminLogin() before}
 	 *
 	 * @return  void
+	 *
+	 * @since   3.0.0
 	 */
 	public function setErrorReportingToDevelopment()
 	{
-		$I = $this;
 		$this->debug('I open Joomla Global Configuration Page');
-		$I->amOnPage('/administrator/index.php?option=com_config');
+		$this->amOnPage('/administrator/index.php?option=com_config');
 		$this->debug('I wait for Global Configuration title');
-		$I->waitForText('Global Configuration', TIMEOUT, ['css' => '.page-title']);
+		$this->waitForText('Global Configuration', TIMEOUT, ['css' => '.page-title']);
 		$this->debug('I open the Server Tab');
-		$I->click(['link' => 'Server']);
+		$this->click(['link' => 'Server']);
 		$this->debug('I wait for error reporting dropdown');
-		$I->selectOptionInChosen('Error Reporting', 'Development');
+		$this->selectOptionInChosen('Error Reporting', 'Development');
 		$this->debug('I click on save');
-		$I->click(['xpath' => "//div[@id='toolbar-apply']//button"]);
+		$this->click(['xpath' => "//div[@id='toolbar-apply']//button"]);
 		$this->debug('I wait for global configuration being saved');
-		$I->waitForText('Global Configuration', TIMEOUT, ['css' => '.page-title']);
-		$I->see('Configuration saved.', ['id' => 'system-message-container']);
+		$this->waitForText('Global Configuration', TIMEOUT, ['css' => '.page-title']);
+		$this->see('Configuration saved.', ['id' => 'system-message-container']);
 	}
 
 	/**
@@ -363,7 +382,9 @@ class JoomlaBrowser extends WebDriver
 	 *
 	 * @deprecated  since Joomla 3.4.4-dev. Use installExtensionFromFolder($path, $type = 'Extension') instead.
 	 *
-	 * @return      void
+	 * @return   void
+	 *
+	 * @since    3.0.0
 	 */
 	public function installExtensionFromDirectory($path, $type = 'Extension')
 	{
@@ -380,17 +401,19 @@ class JoomlaBrowser extends WebDriver
 	 * {@internal doAdminLogin() before}
 	 *
 	 * @return    void
+	 *
+	 * @since    3.0.0
 	 */
 	public function installExtensionFromFolder($path, $type = 'Extension')
 	{
-		$I = $this;
-		$I->amOnPage('/administrator/index.php?option=com_installer');
-		$I->waitForText('Extensions: Install', '30', ['css' => 'H1']);
-		$I->click(['link' => 'Install from Folder']);
+
+		$this->amOnPage('/administrator/index.php?option=com_installer');
+		$this->waitForText('Extensions: Install', '30', ['css' => 'H1']);
+		$this->click(['link' => 'Install from Folder']);
 		$this->debug('I enter the Path');
-		$I->fillField(['id' => 'install_directory'], $path);
-		$I->click(['id' => 'installbutton_directory']);
-		$I->waitForText('was successful', 'TIMEOUT', ['id' => 'system-message-container']);
+		$this->fillField(['id' => 'install_directory'], $path);
+		$this->click(['id' => 'installbutton_directory']);
+		$this->waitForText('was successful', 'TIMEOUT', ['id' => 'system-message-container']);
 		$this->debug("$type successfully installed from $path");
 	}
 
@@ -403,17 +426,18 @@ class JoomlaBrowser extends WebDriver
 	 * {@internal doAdminLogin() before}
 	 *
 	 * @return    void
+	 *
+	 * @since    3.0.0
 	 */
 	public function installExtensionFromUrl($url, $type = 'Extension')
 	{
-		$I = $this;
-		$I->amOnPage('/administrator/index.php?option=com_installer');
-		$I->waitForText('Extensions: Install', '30', ['css' => 'H1']);
-		$I->click(['link' => 'Install from URL']);
+		$this->amOnPage('/administrator/index.php?option=com_installer');
+		$this->waitForText('Extensions: Install', '30', ['css' => 'H1']);
+		$this->click(['link' => 'Install from URL']);
 		$this->debug('I enter the url');
-		$I->fillField(['id' => 'install_url'], $url);
-		$I->click(['id' => 'installbutton_url']);
-		$I->waitForText('was successful', '30', ['id' => 'system-message-container']);
+		$this->fillField(['id' => 'install_url'], $url);
+		$this->click(['id' => 'installbutton_url']);
+		$this->waitForText('was successful', '30', ['id' => 'system-message-container']);
 
 		if ($type == 'Extension')
 		{
@@ -439,23 +463,23 @@ class JoomlaBrowser extends WebDriver
 	 * {@internal doAdminLogin() before}
 	 *
 	 * @return    void
+	 *
+	 * @since    3.0.0
 	 */
 	public function checkForPhpNoticesOrWarnings($page = null)
 	{
-		$I = $this;
-
 		if ($page)
 		{
-			$I->amOnPage($page);
+			$this->amOnPage($page);
 		}
 
-		$I->dontSeeInPageSource('Notice:');
-		$I->dontSeeInPageSource('<b>Notice</b>:');
-		$I->dontSeeInPageSource('Warning:');
-		$I->dontSeeInPageSource('<b>Warning</b>:');
-		$I->dontSeeInPageSource('Strict standards:');
-		$I->dontSeeInPageSource('<b>Strict standards</b>:');
-		$I->dontSeeInPageSource('The requested page can\'t be found');
+		$this->dontSeeInPageSource('Notice:');
+		$this->dontSeeInPageSource('<b>Notice</b>:');
+		$this->dontSeeInPageSource('Warning:');
+		$this->dontSeeInPageSource('<b>Warning</b>:');
+		$this->dontSeeInPageSource('Strict standards:');
+		$this->dontSeeInPageSource('<b>Strict standards</b>:');
+		$this->dontSeeInPageSource('The requested page can\'t be found');
 	}
 
 	/**
@@ -465,15 +489,17 @@ class JoomlaBrowser extends WebDriver
 	 * @param   string  $option  The text in the <option> to be selected in the chosen radio button
 	 *
 	 * @return  void
+	 *
+	 * @since   3.0.0
 	 */
 	public function selectOptionInRadioField($label, $option)
 	{
-		$I = $this;
-		$I->debug("Trying to select the $option from the $label");
-		$label = $I->findField(['xpath' => "//label[contains(normalize-space(string(.)), '$label')]"]);
+
+		$this->debug("Trying to select the $option from the $label");
+		$label = $this->findField(['xpath' => "//label[contains(normalize-space(string(.)), '$label')]"]);
 		$radioId = $label->getAttribute('for');
 
-		$I->click("//fieldset[@id='$radioId']/label[contains(normalize-space(string(.)), '$option')]");
+		$this->click("//fieldset[@id='$radioId']/label[contains(normalize-space(string(.)), '$option')]");
 	}
 
 	/**
@@ -482,21 +508,23 @@ class JoomlaBrowser extends WebDriver
 	 * @param   string  $label   The text in the <label> with for attribute that links to the <select> element
 	 * @param   string  $option  The text in the <option> to be selected in the chosen selector
 	 *
-	 * @return void
+	 * @return  void
+	 *
+	 * @since    3.0.0
 	 */
 	public function selectOptionInChosen($label, $option)
 	{
 		$select = $this->findField($label);
 		$selectID = $select->getAttribute('id');
 		$chosenSelectID = $selectID . '_chzn';
-		$I = $this;
+
 		$this->debug("I open the $label chosen selector");
-		$I->click(['xpath' => "//div[@id='$chosenSelectID']/a/div/b"]);
+		$this->click(['xpath' => "//div[@id='$chosenSelectID']/a/div/b"]);
 		$this->debug("I select $option");
-		$I->click(['xpath' => "//div[@id='$chosenSelectID']//li[text()='$option']"]);
+		$this->click(['xpath' => "//div[@id='$chosenSelectID']//li[text()='$option']"]);
 
 		// Gives time to chosen to close
-		$I->wait(1);
+		$this->wait(1);
 	}
 
 	/**
@@ -505,22 +533,24 @@ class JoomlaBrowser extends WebDriver
 	 * @param   string  $label   The text in the <label> with for attribute that links to the <select> element
 	 * @param   string  $option  The text in the <option> to be selected in the chosen selector
 	 *
-	 * @return void
+	 * @return  void
+	 *
+	 * @since    3.0.0
 	 */
 	public function selectOptionInChosenWithTextField($label, $option)
 	{
 		$select = $this->findField($label);
 		$selectID = $select->getAttribute('id');
 		$chosenSelectID = $selectID . '_chzn';
-		$I = $this;
+
 		$this->debug("I open the $label chosen selector");
-		$I->click(['css' => 'div#' . $chosenSelectID]);
+		$this->click(['css' => 'div#' . $chosenSelectID]);
 		$this->debug("I select $option");
-		$I->fillField(['xpath' => "//div[@id='$chosenSelectID']/div/div/input"], $option);
-		$I->click(['xpath' => "//div[@id='$chosenSelectID']/div/ul/li[1]"]);
+		$this->fillField(['xpath' => "//div[@id='$chosenSelectID']/div/div/input"], $option);
+		$this->click(['xpath' => "//div[@id='$chosenSelectID']/div/ul/li[1]"]);
 
 		// Gives time to chosen to close
-		$I->wait(1);
+		$this->wait(1);
 	}
 
 	/**
@@ -534,14 +564,14 @@ class JoomlaBrowser extends WebDriver
 	public function selectOptionInChosenById($selectId, $option)
 	{
 		$chosenSelectID = $selectId . '_chzn';
-		$I = $this;
+
 		$this->debug("I open the $chosenSelectID chosen selector");
-		$I->click(['xpath' => "//div[@id='$chosenSelectID']/a/div/b"]);
+		$this->click(['xpath' => "//div[@id='$chosenSelectID']/a/div/b"]);
 		$this->debug("I select $option");
-		$I->click(['xpath' => "//div[@id='$chosenSelectID']//li[text()='$option']"]);
+		$this->click(['xpath' => "//div[@id='$chosenSelectID']//li[text()='$option']"]);
 
 		// Gives time to chosen to close
-		$I->wait(1);
+		$this->wait(1);
 	}
 
 	/**
@@ -550,19 +580,19 @@ class JoomlaBrowser extends WebDriver
 	 * @param   string  $selectId  The id of the <select> element
 	 * @param   string  $option    The text in the <option> to be selected in the chosen selector
 	 *
-	 * @return void
+	 * @return  void
+	 *
+	 * @since    3.0.0
 	 */
 	public function selectOptionInChosenByIdUsingJs($selectId, $option)
 	{
-		$I = $this;
-
 		$option = trim($option);
-		$I->executeJS("jQuery('#$selectId option').filter(function(){ return this.text.trim() === \"$option\" }).prop('selected', true);");
-		$I->executeJS("jQuery('#$selectId').trigger('liszt:updated').trigger('chosen:updated');");
-		$I->executeJS("jQuery('#$selectId').trigger('change');");
+		$this->executeJS("jQuery('#$selectId option').filter(function(){ return this.text.trim() === \"$option\" }).prop('selected', true);");
+		$this->executeJS("jQuery('#$selectId').trigger('liszt:updated').trigger('chosen:updated');");
+		$this->executeJS("jQuery('#$selectId').trigger('change');");
 
 		// Give time to Chosen to update
-		$I->wait(1);
+		$this->wait(1);
 	}
 
 	/**
@@ -571,41 +601,44 @@ class JoomlaBrowser extends WebDriver
 	 * @param   string  $label    Label of the select field
 	 * @param   array   $options  Array of options to be selected
 	 *
-	 * @return void
+	 * @return  void
+	 *
+	 * @since   3.0.0
 	 */
 	public function selectMultipleOptionsInChosen($label, $options)
 	{
 		$select = $this->findField($label);
 		$selectID = $select->getAttribute('id');
 		$chosenSelectID = $selectID . '_chzn';
-		$I = $this;
+
 
 		foreach ($options as $option)
 		{
 			$this->debug("I open the $label chosen selector");
-			$I->click(['xpath' => "//div[@id='$chosenSelectID']/ul"]);
+			$this->click(['xpath' => "//div[@id='$chosenSelectID']/ul"]);
 			$this->debug("I select $option");
-			$I->click(['xpath' => "//div[@id='$chosenSelectID']//li[contains(text()[normalize-space()], '$option')]"]);
+			$this->click(['xpath' => "//div[@id='$chosenSelectID']//li[contains(text()[normalize-space()], '$option')]"]);
 
 			// Gives time to chosen to close
-			$I->wait(1);
+			$this->wait(1);
 		}
 	}
 
 	/**
 	 * Function to Logout from Administrator Panel in Joomla!
 	 *
-	 * @return void
+	 * @return  void
+	 *
+	 * @since   3.0.0
 	 */
 	public function doAdministratorLogout()
 	{
-		$I = $this;
-		$I->click(['xpath' => "//ul[@class='nav nav-user pull-right']//li//a[@class='dropdown-toggle']"]);
+		$this->click(['xpath' => "//ul[@class='nav nav-user pull-right']//li//a[@class='dropdown-toggle']"]);
 		$this->debug("I click on Top Right corner toggle to Logout from Admin");
-		$I->waitForElement(['xpath' => "//li[@class='dropdown open']/ul[@class='dropdown-menu']//a[text() = 'Logout']"], TIMEOUT);
-		$I->click(['xpath' => "//li[@class='dropdown open']/ul[@class='dropdown-menu']//a[text() = 'Logout']"]);
-		$I->waitForElement(['id' => 'mod-login-username'], TIMEOUT);
-		$I->waitForText('Log in', TIMEOUT, ['xpath' => "//fieldset[@class='loginform']//button"]);
+		$this->waitForElement(['xpath' => "//li[@class='dropdown open']/ul[@class='dropdown-menu']//a[text() = 'Logout']"], TIMEOUT);
+		$this->click(['xpath' => "//li[@class='dropdown open']/ul[@class='dropdown-menu']//a[text() = 'Logout']"]);
+		$this->waitForElement(['id' => 'mod-login-username'], TIMEOUT);
+		$this->waitForText('Log in', TIMEOUT, ['xpath' => "//fieldset[@class='loginform']//button"]);
 	}
 
 	/**
@@ -613,20 +646,21 @@ class JoomlaBrowser extends WebDriver
 	 *
 	 * @param   String  $pluginName  Name of the Plugin
 	 *
-	 * @return void
+	 * @return  void
+	 *
+	 * @since   3.0.0
 	 */
 	public function enablePlugin($pluginName)
 	{
-		$I = $this;
-		$I->amOnPage('/administrator/index.php?option=com_plugins');
+		$this->amOnPage('/administrator/index.php?option=com_plugins');
 		$this->debug('I check for Notices and Warnings');
 		$this->checkForPhpNoticesOrWarnings();
-		$I->searchForItem($pluginName);
-		$I->waitForElement($this->searchResultPluginName($pluginName), 30);
-		$I->checkExistenceOf($pluginName);
-		$I->click(['xpath' => "//input[@id='cb0']"]);
-		$I->click(['xpath' => "//div[@id='toolbar-publish']/button"]);
-		$I->see('successfully enabled', ['id' => 'system-message-container']);
+		$this->searchForItem($pluginName);
+		$this->waitForElement($this->searchResultPluginName($pluginName), 30);
+		$this->checkExistenceOf($pluginName);
+		$this->click(['xpath' => "//input[@id='cb0']"]);
+		$this->click(['xpath' => "//div[@id='toolbar-publish']/button"]);
+		$this->see('successfully enabled', ['id' => 'system-message-container']);
 	}
 
 	/**
@@ -634,7 +668,9 @@ class JoomlaBrowser extends WebDriver
 	 *
 	 * @param   String  $pluginName  Name of the Plugin
 	 *
-	 * @return string
+	 * @return  string
+	 *
+	 * @since   3.0.0
 	 */
 	private function searchResultPluginName($pluginName)
 	{
@@ -649,26 +685,27 @@ class JoomlaBrowser extends WebDriver
 	 * @param   string  $extensionName  Is important to use a specific
 	 *
 	 * @return  void
+	 *
+	 * @since   3.0.0
 	 */
 	public function uninstallExtension($extensionName)
 	{
-		$I = $this;
-		$I->amOnPage('/administrator/index.php?option=com_installer&view=manage');
-		$I->waitForText('Extensions: Manage', '30', ['css' => 'H1']);
-		$I->searchForItem($extensionName);
-		$I->waitForElement(['id' => 'manageList'], '30');
-		$I->click(['xpath' => "//input[@id='cb0']"]);
-		$I->click(['xpath' => "//div[@id='toolbar-delete']/button"]);
-		$I->acceptPopup();
-		$I->waitForText('was successful', '30', ['id' => 'system-message-container']);
-		$I->see('was successful', ['id' => 'system-message-container']);
-		$I->searchForItem($extensionName);
-		$I->waitForText(
+		$this->amOnPage('/administrator/index.php?option=com_installer&view=manage');
+		$this->waitForText('Extensions: Manage', '30', ['css' => 'H1']);
+		$this->searchForItem($extensionName);
+		$this->waitForElement(['id' => 'manageList'], '30');
+		$this->click(['xpath' => "//input[@id='cb0']"]);
+		$this->click(['xpath' => "//div[@id='toolbar-delete']/button"]);
+		$this->acceptPopup();
+		$this->waitForText('was successful', '30', ['id' => 'system-message-container']);
+		$this->see('was successful', ['id' => 'system-message-container']);
+		$this->searchForItem($extensionName);
+		$this->waitForText(
 			'There are no extensions installed matching your query.',
 			TIMEOUT,
 			['class' => 'alert-no-items']
 		);
-		$I->see('There are no extensions installed matching your query.', ['class' => 'alert-no-items']);
+		$this->see('There are no extensions installed matching your query.', ['class' => 'alert-no-items']);
 		$this->debug('Extension successfully uninstalled');
 	}
 
@@ -678,22 +715,22 @@ class JoomlaBrowser extends WebDriver
 	 * @param   String  $name  Name of the Item which we need to Search
 	 *
 	 * @return void
+	 *
+	 * @since   3.0.0
 	 */
 	public function searchForItem($name = null)
 	{
-		$I = $this;
-
 		if ($name)
 		{
-			$I->debug("Searching for $name");
-			$I->fillField(['id' => "filter_search"], $name);
-			$I->click(['xpath' => "//button[@type='submit' and @data-original-title='Search']"]);
+			$this->debug("Searching for $name");
+			$this->fillField(['id' => "filter_search"], $name);
+			$this->click(['xpath' => "//button[@type='submit' and @data-original-title='Search']"]);
+			
+			return;
 		}
-		else
-		{
-			$I->debug('clearing search filter');
-			$I->click(['xpath' => "//button[@type='button' and @data-original-title='Clear']"]);
-		}
+
+		$this->debug('clearing search filter');
+		$this->click(['xpath' => "//button[@type='button' and @data-original-title='Clear']"]);
 	}
 
 	/**
@@ -708,10 +745,9 @@ class JoomlaBrowser extends WebDriver
 	 */
 	public function checkExistenceOf($name)
 	{
-		$I = $this;
-		$I->debug("Verifying if $name exist in search result");
-		$I->seeElement(['xpath' => "//form[@id='adminForm']/div/table/tbody"]);
-		$I->see($name, ['xpath' => "//form[@id='adminForm']/div/table/tbody"]);
+		$this->debug("Verifying if $name exist in search result");
+		$this->seeElement(['xpath' => "//form[@id='adminForm']/div/table/tbody"]);
+		$this->see($name, ['xpath' => "//form[@id='adminForm']/div/table/tbody"]);
 	}
 
 	/**
@@ -723,9 +759,9 @@ class JoomlaBrowser extends WebDriver
 	 */
 	public function checkAllResults()
 	{
-		$I = $this;
+
 		$this->debug("Selecting Checkall button");
-		$I->click(['xpath' => "//thead//input[@name='checkall-toggle' or @name='toggle']"]);
+		$this->click(['xpath' => "//thead//input[@name='checkall-toggle' or @name='toggle']"]);
 	}
 
 	/**
@@ -737,19 +773,19 @@ class JoomlaBrowser extends WebDriver
 	 */
 	public function installLanguage($languageName)
 	{
-		$I = $this;
-		$I->amOnPage('administrator/index.php?option=com_installer&view=languages');
+
+		$this->amOnPage('administrator/index.php?option=com_installer&view=languages');
 		$this->debug('I check for Notices and Warnings');
 		$this->checkForPhpNoticesOrWarnings();
 		$this->debug('Refreshing languages');
-		$I->click(['xpath' => "//div[@id='toolbar-refresh']/button"]);
-		$I->waitForElement(['id' => 'j-main-container'], 30);
-		$I->searchForItem($languageName);
-		$I->waitForElement($this->searchResultLanguageName($languageName), 30);
-		$I->click(['id' => "cb0"]);
-		$I->click(['xpath' => "//div[@id='toolbar-upload']/button"]);
-		$I->waitForText('was successful.', TIMEOUT, ['id' => 'system-message-container']);
-		$I->see('No Matching Results', ['class' => 'alert-no-items']);
+		$this->click(['xpath' => "//div[@id='toolbar-refresh']/button"]);
+		$this->waitForElement(['id' => 'j-main-container'], 30);
+		$this->searchForItem($languageName);
+		$this->waitForElement($this->searchResultLanguageName($languageName), 30);
+		$this->click(['id' => "cb0"]);
+		$this->click(['xpath' => "//div[@id='toolbar-upload']/button"]);
+		$this->waitForText('was successful.', TIMEOUT, ['id' => 'system-message-container']);
+		$this->see('No Matching Results', ['class' => 'alert-no-items']);
 		$this->debug($languageName . ' successfully installed');
 	}
 
@@ -777,16 +813,15 @@ class JoomlaBrowser extends WebDriver
 	 */
 	public function setModulePosition($module, $position = 'position-7')
 	{
-		$I = $this;
-		$I->amOnPage('administrator/index.php?option=com_modules');
-		$I->searchForItem($module);
-		$I->click(['link' => $module]);
-		$I->waitForText("Modules: $module", 30, ['css' => 'h1.page-title']);
-		$I->click(['link' => 'Module']);
-		$I->waitForElement(['id' => 'general'], 30);
-		$I->selectOptionInChosen('Position', $position);
-		$I->click(['xpath' => "//div[@id='toolbar-apply']/button"]);
-		$I->waitForText('Module successfully saved', 30, ['id' => 'system-message-container']);
+		$this->amOnPage('administrator/index.php?option=com_modules');
+		$this->searchForItem($module);
+		$this->click(['link' => $module]);
+		$this->waitForText("Modules: $module", 30, ['css' => 'h1.page-title']);
+		$this->click(['link' => 'Module']);
+		$this->waitForElement(['id' => 'general'], 30);
+		$this->selectOptionInChosen('Position', $position);
+		$this->click(['xpath' => "//div[@id='toolbar-apply']/button"]);
+		$this->waitForText('Module successfully saved', 30, ['id' => 'system-message-container']);
 	}
 
 	/**
@@ -795,15 +830,15 @@ class JoomlaBrowser extends WebDriver
 	 * @param   string  $module  The full name of the module
 	 *
 	 * @return  void
+	 * @since   3.0.0
 	 */
 	public function publishModule($module)
 	{
-		$I = $this;
-		$I->amOnPage('administrator/index.php?option=com_modules');
-		$I->searchForItem($module);
-		$I->checkAllResults();
-		$I->click(['xpath' => "//div[@id='toolbar-publish']/button"]);
-		$I->waitForText('1 module successfully published.', 30, ['id' => 'system-message-container']);
+		$this->amOnPage('administrator/index.php?option=com_modules');
+		$this->searchForItem($module);
+		$this->checkAllResults();
+		$this->click(['xpath' => "//div[@id='toolbar-publish']/button"]);
+		$this->waitForText('1 module successfully published.', 30, ['id' => 'system-message-container']);
 	}
 
 	/**
@@ -812,20 +847,20 @@ class JoomlaBrowser extends WebDriver
 	 * @param   string  $module  The full name of the module
 	 *
 	 * @return  void
+	 * @since   3.0.0
 	 */
 	public function displayModuleOnAllPages($module)
 	{
-		$I = $this;
-		$I->amOnPage('administrator/index.php?option=com_modules');
-		$I->searchForItem($module);
-		$I->click(['link' => $module]);
-		$I->waitForElement(['link' => 'Menu Assignment'], 30);
-		$I->click(['link' => 'Menu Assignment']);
-		$I->waitForElement(['id' => 'jform_menus-lbl'], 30);
-		$I->click(['id' => 'jform_assignment_chzn']);
-		$I->click(['xpath' => "//li[@data-option-array-index='0']"]);
-		$I->click(['xpath' => "//div[@id='toolbar-apply']/button"]);
-		$I->waitForText('Module successfully saved', 30, ['id' => 'system-message-container']);
+		$this->amOnPage('administrator/index.php?option=com_modules');
+		$this->searchForItem($module);
+		$this->click(['link' => $module]);
+		$this->waitForElement(['link' => 'Menu Assignment'], 30);
+		$this->click(['link' => 'Menu Assignment']);
+		$this->waitForElement(['id' => 'jform_menus-lbl'], 30);
+		$this->click(['id' => 'jform_assignment_chzn']);
+		$this->click(['xpath' => "//li[@data-option-array-index='0']"]);
+		$this->click(['xpath' => "//div[@id='toolbar-apply']/button"]);
+		$this->waitForText('Module successfully saved', 30, ['id' => 'system-message-container']);
 	}
 
 	/**
@@ -834,65 +869,65 @@ class JoomlaBrowser extends WebDriver
 	 * @param   string  $button  The full name of the button
 	 *
 	 * @return  void
+	 * @since   3.0.0
 	 */
 	public function clickToolbarButton($button)
 	{
-		$I = $this;
 		$input = strtolower($button);
 
 		$screenSize = explode("x", $this->config['window_size']);
 
 		if ($screenSize[0] <= 480)
 		{
-			$I->click('Toolbar');
+			$this->click('Toolbar');
 		}
 
 		switch ($input)
 		{
 			case "new":
-				$I->click(['xpath' => "//div[@id='toolbar-new']//button"]);
+				$this->click(['xpath' => "//div[@id='toolbar-new']//button"]);
 				break;
 			case "edit":
-				$I->click(['xpath' => "//div[@id='toolbar-edit']//button"]);
+				$this->click(['xpath' => "//div[@id='toolbar-edit']//button"]);
 				break;
 			case "publish":
-				$I->click(['xpath' => "//div[@id='toolbar-publish']//button"]);
+				$this->click(['xpath' => "//div[@id='toolbar-publish']//button"]);
 				break;
 			case "unpublish":
-				$I->click(['xpath' => "//div[@id='toolbar-unpublish']//button"]);
+				$this->click(['xpath' => "//div[@id='toolbar-unpublish']//button"]);
 				break;
 			case "archive":
-				$I->click(['xpath' => "//div[@id='toolbar-archive']//button"]);
+				$this->click(['xpath' => "//div[@id='toolbar-archive']//button"]);
 				break;
 			case "check-in":
-				$I->click(['xpath' => "//div[@id='toolbar-checkin']//button"]);
+				$this->click(['xpath' => "//div[@id='toolbar-checkin']//button"]);
 				break;
 			case "batch":
-				$I->click(['xpath' => "//div[@id='toolbar-batch']//button"]);
+				$this->click(['xpath' => "//div[@id='toolbar-batch']//button"]);
 				break;
 			case "rebuild":
-				$I->click(['xpath' => "//div[@id='toolbar-refresh']//button"]);
+				$this->click(['xpath' => "//div[@id='toolbar-refresh']//button"]);
 				break;
 			case "trash":
-				$I->click(['xpath' => "//div[@id='toolbar-trash']//button"]);
+				$this->click(['xpath' => "//div[@id='toolbar-trash']//button"]);
 				break;
 			case "save":
-				$I->click(['xpath' => "//div[@id='toolbar-apply']//button"]);
+				$this->click(['xpath' => "//div[@id='toolbar-apply']//button"]);
 				break;
 			case "save & close":
-				$I->click(['xpath' => "//div[@id='toolbar-save']//button"]);
+				$this->click(['xpath' => "//div[@id='toolbar-save']//button"]);
 				break;
 			case "save & new":
-				$I->click(['xpath' => "//div[@id='toolbar-save-new']//button"]);
+				$this->click(['xpath' => "//div[@id='toolbar-save-new']//button"]);
 				break;
 			case "cancel":
-				$I->click(['xpath' => "//div[@id='toolbar-cancel']//button"]);
+				$this->click(['xpath' => "//div[@id='toolbar-cancel']//button"]);
 				break;
 			case "options":
-				$I->click(['xpath' => "//div[@id='toolbar-options']//button"]);
+				$this->click(['xpath' => "//div[@id='toolbar-options']//button"]);
 				break;
 			case "empty trash":
-				$I->click(['xpath' => "//div[@id='toolbar-delete']//button"]);
+				$this->click(['xpath' => "//div[@id='toolbar-delete']//button"]);
 				break;
 		}
 	}
@@ -907,54 +942,54 @@ class JoomlaBrowser extends WebDriver
 	 * @param   string  $language      If you are using Multilingual feature, the language for the menu
 	 *
 	 * @return  void
+	 *
+	 * @since   3.0.0
 	 */
 	public function createMenuItem($menuTitle, $menuCategory, $menuItem, $menu = 'Main Menu', $language = 'All')
 	{
-		$I = $this;
-
-		$I->debug("I open the menus page");
-		$I->amOnPage('administrator/index.php?option=com_menus&view=menus');
-		$I->waitForText('Menus', 'TIMEOUT', ['css' => 'H1']);
+		$this->debug("I open the menus page");
+		$this->amOnPage('administrator/index.php?option=com_menus&view=menus');
+		$this->waitForText('Menus', 'TIMEOUT', ['css' => 'H1']);
 		$this->checkForPhpNoticesOrWarnings();
 
-		$I->debug("I click in the menu: $menu");
-		$I->click(['link' => $menu]);
-		$I->waitForText('Menus: Items', 'TIMEOUT', ['css' => 'H1']);
+		$this->debug("I click in the menu: $menu");
+		$this->click(['link' => $menu]);
+		$this->waitForText('Menus: Items', 'TIMEOUT', ['css' => 'H1']);
 		$this->checkForPhpNoticesOrWarnings();
 
-		$I->debug("I click new");
-		$I->click("New");
-		$I->waitForText('Menus: New Item', 'TIMEOUT', ['css' => 'h1']);
+		$this->debug("I click new");
+		$this->click("New");
+		$this->waitForText('Menus: New Item', 'TIMEOUT', ['css' => 'h1']);
 		$this->checkForPhpNoticesOrWarnings();
-		$I->fillField(['id' => 'jform_title'], $menuTitle);
+		$this->fillField(['id' => 'jform_title'], $menuTitle);
 
-		$I->debug("Open the menu types iframe");
-		$I->click(['link' => "Select"]);
-		$I->waitForElement(['id' => 'menuTypeModal'], 'TIMEOUT');
-		$I->wait(1);
-		$I->switchToIFrame("Menu Item Type");
+		$this->debug("Open the menu types iframe");
+		$this->click(['link' => "Select"]);
+		$this->waitForElement(['id' => 'menuTypeModal'], 'TIMEOUT');
+		$this->wait(1);
+		$this->switchToIFrame("Menu Item Type");
 
-		$I->debug("Open the menu category: $menuCategory");
+		$this->debug("Open the menu category: $menuCategory");
 
 		// Open the category
-		$I->wait(1);
-		$I->waitForElement(['link' => $menuCategory], 'TIMEOUT');
-		$I->click(['link' => $menuCategory]);
+		$this->wait(1);
+		$this->waitForElement(['link' => $menuCategory], 'TIMEOUT');
+		$this->click(['link' => $menuCategory]);
 
-		$I->debug("Choose the menu item type: $menuItem");
-		$I->wait(1);
-		$I->waitForElement(['xpath' => "//a[contains(text()[normalize-space()], '$menuItem')]"], 'TIMEOUT');
-		$I->click(['xpath' => "//div[@id='collapseTypes']//a[contains(text()[normalize-space()], '$menuItem')]"]);
-		$I->debug('I switch back to the main window');
-		$I->switchToIFrame();
-		$I->debug('I leave time to the iframe to close');
-		$I->wait(2);
-		$I->selectOptionInChosen('Language', $language);
-		$I->waitForText('Menus: New Item', '30', ['css' => 'h1']);
-		$I->debug('I save the menu');
-		$I->click("Save");
+		$this->debug("Choose the menu item type: $menuItem");
+		$this->wait(1);
+		$this->waitForElement(['xpath' => "//a[contains(text()[normalize-space()], '$menuItem')]"], 'TIMEOUT');
+		$this->click(['xpath' => "//div[@id='collapseTypes']//a[contains(text()[normalize-space()], '$menuItem')]"]);
+		$this->debug('I switch back to the main window');
+		$this->switchToIFrame();
+		$this->debug('I leave time to the iframe to close');
+		$this->wait(2);
+		$this->selectOptionInChosen('Language', $language);
+		$this->waitForText('Menus: New Item', '30', ['css' => 'h1']);
+		$this->debug('I save the menu');
+		$this->click("Save");
 
-		$I->waitForText('Menu item successfully saved', 'TIMEOUT', ['id' => 'system-message-container']);
+		$this->waitForText('Menu item successfully saved', 'TIMEOUT', ['id' => 'system-message-container']);
 	}
 
 	/**
@@ -963,11 +998,14 @@ class JoomlaBrowser extends WebDriver
 	 * @param   string  $label  Label of the Filter you want to use.
 	 * @param   string  $value  Value you want to set in the filters.
 	 *
-	 * @return void
+	 * @return  void
+	 *
+	 * @since   3.0.0
 	 */
 	public function setFilter($label, $value)
 	{
 		$label = strtolower($label);
+
 		$filters = array(
 			"select status" 	=> "filter_published",
 			"select access"		=> "filter_access",
@@ -976,37 +1014,38 @@ class JoomlaBrowser extends WebDriver
 			"select max levels"	=> "filter_level"
 		);
 
-		$I = $this;
-		$I->click(['xpath' => "//button[@data-original-title='Filter the list items.']"]);
-		$I->debug('I try to select the filters');
+		$this->click(['xpath' => "//button[@data-original-title='Filter the list items.']"]);
+		$this->debug('I try to select the filters');
 
 		foreach ($filters as $fieldName => $id)
 		{
 			if ($fieldName == $label)
 			{
-				$I->selectOptionInChosenByIdUsingJs($id, $value);
+				$this->selectOptionInChosenByIdUsingJs($id, $value);
 			}
 		}
 
-		$I->debug('Applied filters');
+		$this->debug('Applied filters');
 	}
 
 	/**
 	 * Function to Verify the Tabs on a Joomla! screen
 	 *
-	 * @param   Array  $expectedTabs  Expected Tabs on the Page
+	 * @param   array  $expectedTabs  Expected Tabs on the Page
 	 * @param   Mixed  $tabsLocator   Locator for the Tabs in Edit View
 	 *
-	 * @return void
+	 * @return  void
+	 *
+	 * @since   3.0.0
 	 */
 	public function verifyAvailableTabs($expectedTabs, $tabsLocator = ['xpath' => "//ul[@id='myTabTabs']/li/a"])
 	{
-		$I = $this;
-		$actualArrayOfTabs = $I->grabMultiple($tabsLocator);
-		$I->debug("Fetch the current list of Tabs in the edit view which is: " . implode(", ", $actualArrayOfTabs));
-		$url = $I->grabFromCurrentUrl();
-		$I->assertEquals($expectedTabs, $actualArrayOfTabs, "Tab Labels do not match on edit view of" . $url);
-		$I->debug('Verify the Tabs');
+		$actualArrayOfTabs = $this->grabMultiple($tabsLocator);
+
+		$this->debug("Fetch the current list of Tabs in the edit view which is: " . implode(", ", $actualArrayOfTabs));
+		$url = $this->grabFromCurrentUrl();
+		$this->assertEquals($expectedTabs, $actualArrayOfTabs, "Tab Labels do not match on edit view of" . $url);
+		$this->debug('Verify the Tabs');
 	}
 
 	/**
@@ -1014,14 +1053,15 @@ class JoomlaBrowser extends WebDriver
 	 *
 	 * {@internal doAdminLogin() before}
 	 *
-	 * @return void
+	 * @return  void
+	 *
+	 * @since   3.5.0
 	 */
 	public function disableStatistics()
 	{
-		$I = $this;
 		$this->debug('I click on never');
-		$I->wait(1);
-		$I->waitForElement(['link' => 'Never'], TIMEOUT);
-		$I->click(['link' => 'Never']);
+		$this->wait(1);
+		$this->waitForElement(['link' => 'Never'], TIMEOUT);
+		$this->click(['link' => 'Never']);
 	}
 }

--- a/src/JoomlaBrowser.php
+++ b/src/JoomlaBrowser.php
@@ -661,7 +661,7 @@ class JoomlaBrowser extends WebDriver
 		$this->checkExistenceOf($pluginName);
 		$this->click(['xpath' => "//input[@id='cb0']"]);
 		$this->click(['xpath' => "//div[@id='toolbar-publish']/button"]);
-		$this->see('successfully enabled', ['id' => 'system-message-container']);
+		$this->see(' enabled', ['id' => 'system-message-container']);
 	}
 
 	/**
@@ -822,7 +822,7 @@ class JoomlaBrowser extends WebDriver
 		$this->waitForElement(['id' => 'general'], 30);
 		$this->selectOptionInChosen('Position', $position);
 		$this->click(['xpath' => "//div[@id='toolbar-apply']/button"]);
-		$this->waitForText('Module successfully saved', 30, ['id' => 'system-message-container']);
+		$this->waitForText('Module saved', 30, ['id' => 'system-message-container']);
 	}
 
 	/**
@@ -839,7 +839,7 @@ class JoomlaBrowser extends WebDriver
 		$this->searchForItem($module);
 		$this->checkAllResults();
 		$this->click(['xpath' => "//div[@id='toolbar-publish']/button"]);
-		$this->waitForText('1 module successfully published.', 30, ['id' => 'system-message-container']);
+		$this->waitForText(' published.', 30, ['id' => 'system-message-container']);
 	}
 
 	/**
@@ -861,7 +861,7 @@ class JoomlaBrowser extends WebDriver
 		$this->click(['id' => 'jform_assignment_chzn']);
 		$this->click(['xpath' => "//li[@data-option-array-index='0']"]);
 		$this->click(['xpath' => "//div[@id='toolbar-apply']/button"]);
-		$this->waitForText('Module successfully saved', 30, ['id' => 'system-message-container']);
+		$this->waitForText('Module saved', 30, ['id' => 'system-message-container']);
 	}
 
 	/**

--- a/src/JoomlaBrowser.php
+++ b/src/JoomlaBrowser.php
@@ -184,6 +184,7 @@ class JoomlaBrowser extends WebDriver
 		$this->amOnPage($this->locator->frontEndLoginUrl);
 		$this->debug('I click Logout button');
 		$this->click($this->locator->frontEndLogoutButton);
+		$I->amOnPage('/index.php?option=com_users&view=login');
 		$this->debug('I wait to see Login form');
 		$this->waitForElement($this->locator->frontEndLoginForm, 30);
 		$this->seeElement($this->locator->frontEndLoginForm);

--- a/src/JoomlaBrowser.php
+++ b/src/JoomlaBrowser.php
@@ -7,7 +7,7 @@
  */
 
 namespace Codeception\Module;
-use Joomla\Browser\Locators\Locators;
+use Codeception\Module\Locators\Locators;
 use Codeception\Module\WebDriver;
 const TIMEOUT = 60;
 

--- a/src/JoomlaBrowser.php
+++ b/src/JoomlaBrowser.php
@@ -10,6 +10,7 @@ namespace Codeception\Module;
 
 use Codeception\Module\Locators\Locators;
 use Codeception\Module\WebDriver;
+use Codeception\Lib\ModuleContainer;
 
 const TIMEOUT = 60;
 
@@ -184,7 +185,7 @@ class JoomlaBrowser extends WebDriver
 		$this->amOnPage($this->locator->frontEndLoginUrl);
 		$this->debug('I click Logout button');
 		$this->click($this->locator->frontEndLogoutButton);
-		$I->amOnPage('/index.php?option=com_users&view=login');
+		$this->amOnPage('/index.php?option=com_users&view=login');
 		$this->debug('I wait to see Login form');
 		$this->waitForElement($this->locator->frontEndLoginForm, 30);
 		$this->seeElement($this->locator->frontEndLoginForm);

--- a/src/JoomlaBrowser.php
+++ b/src/JoomlaBrowser.php
@@ -9,7 +9,6 @@
 namespace Codeception\Module;
 use Joomla\Browser\Locators\Locators;
 use Codeception\Module\WebDriver;
-require_once('locator/Locators.php');
 const TIMEOUT = 60;
 
 /**
@@ -85,7 +84,6 @@ class JoomlaBrowser extends WebDriver
 	{
 		$I = $this;
 		$locator = $this->instantiateLocator();
-
 
 		if (is_null($user))
 		{

--- a/src/JoomlaBrowser.php
+++ b/src/JoomlaBrowser.php
@@ -9,6 +9,8 @@
 namespace Codeception\Module;
 
 use Codeception\Module\WebDriver;
+require_once('locator/Locators.php');
+const TIMEOUT = 60;
 
 /**
  * Joomla Browser class to perform test suits for Joomla.
@@ -58,11 +60,12 @@ class JoomlaBrowser extends WebDriver
 	 */
 	public function instantiateLocator()
 	{
-		if (!(isset($this->config['locator class'])) || is_null($this->config['locator class']))
+		if (empty($this->config['locator class']))
 		{
 			$this->locatorObject = new \Locators();
 		}
-		else{
+		else
+		{
 			$temp = $this->config['locator class'];
 			$this->locatorObject = new $temp;
 		}
@@ -96,7 +99,7 @@ class JoomlaBrowser extends WebDriver
 
 		$this->debug('I open Joomla Administrator Login Page');
 		$I->amOnPage($locator::$adminLoginPageUrl);
-		$I->waitForElement($locator::$adminLoginUserName, 60);
+		$I->waitForElement($locator::$adminLoginUserName, TIMEOUT);
 		$this->debug('Fill Username Text Field');
 		$I->fillField($locator::$adminLoginUserName, $user);
 		$this->debug('Fill Password Text Field');
@@ -144,7 +147,7 @@ class JoomlaBrowser extends WebDriver
 		$I->click($locatorObject::$loginButton);
 		$this->debug('I wait to see Frontend Member Profile Form with the Logout button in the module');
 
-		$I->waitForElement($locatorObject::$frontEndLoginSuccess, 60);
+		$I->waitForElement($locatorObject::$frontEndLoginSuccess, TIMEOUT);
 	}
 
 	/**
@@ -191,14 +194,14 @@ class JoomlaBrowser extends WebDriver
 
 		// Select a random language to force reloading of the lang strings after selecting English
 		$I->selectOptionInChosenWithTextField('#jform_language', 'Spanish (Español)');
-		$I->waitForText('Configuración principal', 60, 'h3');
+		$I->waitForText('Configuración principal', TIMEOUT, 'h3');
 
 		// Wait for chosen to render the field
 		$I->debug('I select en-GB as installation language');
 		$I->debug('Wait for chosen to render the Languages list field');
 		$I->wait(2);
 		$I->selectOptionInChosenWithTextField('#jform_language', 'English (United Kingdom)');
-		$I->waitForText('Main Configuration', 60, 'h3');
+		$I->waitForText('Main Configuration', TIMEOUT, 'h3');
 		$this->debug('I fill Site Name');
 		$I->fillField(['id' => 'jform_site_name'], 'Joomla CMS test');
 		$this->debug('I fill Site Description');
@@ -221,7 +224,7 @@ class JoomlaBrowser extends WebDriver
 		$I->click(['link' => 'Next']);
 
 		$this->debug('I Fill the form for creating the Joomla site Database');
-		$I->waitForText('Database Configuration', 60, ['css' => 'h3']);
+		$I->waitForText('Database Configuration', TIMEOUT, ['css' => 'h3']);
 
 		$this->debug('I select MySQLi');
 		$I->selectOption(['id' => 'jform_db_type'], $this->config['database type']);
@@ -244,7 +247,7 @@ class JoomlaBrowser extends WebDriver
 		$I->waitForElementVisible(['id' => 'jform_sample_file-lbl'], 30);
 
 		$this->debug('I install joomla with or without sample data');
-		$I->waitForText('Finalisation', 60, ['xpath' => '//h3']);
+		$I->waitForText('Finalisation', TIMEOUT, ['xpath' => '//h3']);
 
 		// @todo: installation of sample data needs to be created
 
@@ -254,7 +257,7 @@ class JoomlaBrowser extends WebDriver
 
 		// Wait while Joomla gets installed
 		$this->debug('I wait for Joomla being installed');
-		$I->waitForText('Congratulations! Joomla! is now installed.', 60, ['xpath' => '//h3']);
+		$I->waitForText('Congratulations! Joomla! is now installed.', TIMEOUT, ['xpath' => '//h3']);
 	}
 
 	/**
@@ -272,7 +275,7 @@ class JoomlaBrowser extends WebDriver
 		$I->click(['xpath' => "//input[@value='Remove installation folder']"]);
 
 		$I->debug('I wait for Removing Installation Folder button to become disabled');
-		$I->waitForJS("return jQuery('form#adminForm input[name=instDefault]').attr('disabled') == 'disabled';", 60);
+		$I->waitForJS("return jQuery('form#adminForm input[name=instDefault]').attr('disabled') == 'disabled';", TIMEOUT);
 
 		$I->debug('Joomla is now installed');
 		$I->see('Congratulations! Joomla! is now installed.', ['xpath' => '//h3']);
@@ -301,7 +304,7 @@ class JoomlaBrowser extends WebDriver
 
 		$this->debug('I go to Install Languages page');
 		$I->click(['id' => 'instLangs']);
-		$I->waitForText('Install Language packages', 60, ['xpath' => '//h3']);
+		$I->waitForText('Install Language packages', TIMEOUT, ['xpath' => '//h3']);
 
 		foreach ($languages as $language)
 		{
@@ -310,14 +313,14 @@ class JoomlaBrowser extends WebDriver
 		}
 
 		$I->click(['link' => 'Next']);
-		$I->waitForText('Multilingual', 60, ['xpath' => '//h3']);
+		$I->waitForText('Multilingual', TIMEOUT, ['xpath' => '//h3']);
 		$I->selectOptionInRadioField('Activate the multilingual feature', 'Yes');
 		$I->waitForElementVisible(['id' => 'jform_activatePluginLanguageCode-lbl']);
 		$I->selectOptionInRadioField('Install localised content', 'Yes');
 		$I->selectOptionInRadioField('Enable the language code plugin', 'Yes');
 		$I->click(['link' => 'Next']);
 
-		$I->waitForText('Congratulations! Joomla! is now installed.', 60, ['xpath' => '//h3']);
+		$I->waitForText('Congratulations! Joomla! is now installed.', TIMEOUT, ['xpath' => '//h3']);
 		$this->debug('Removing Installation Folder');
 		$I->click(['xpath' => "//input[@value='Remove installation folder']"]);
 
@@ -340,7 +343,7 @@ class JoomlaBrowser extends WebDriver
 		$this->debug('I open Joomla Global Configuration Page');
 		$I->amOnPage('/administrator/index.php?option=com_config');
 		$this->debug('I wait for Global Configuration title');
-		$I->waitForText('Global Configuration', 60, ['css' => '.page-title']);
+		$I->waitForText('Global Configuration', TIMEOUT, ['css' => '.page-title']);
 		$this->debug('I open the Server Tab');
 		$I->click(['link' => 'Server']);
 		$this->debug('I wait for error reporting dropdown');
@@ -348,7 +351,7 @@ class JoomlaBrowser extends WebDriver
 		$this->debug('I click on save');
 		$I->click(['xpath' => "//div[@id='toolbar-apply']//button"]);
 		$this->debug('I wait for global configuration being saved');
-		$I->waitForText('Global Configuration', 60, ['css' => '.page-title']);
+		$I->waitForText('Global Configuration', TIMEOUT, ['css' => '.page-title']);
 		$I->see('Configuration successfully saved.', ['id' => 'system-message-container']);
 	}
 
@@ -389,7 +392,7 @@ class JoomlaBrowser extends WebDriver
 		$this->debug('I enter the Path');
 		$I->fillField(['id' => 'install_directory'], $path);
 		$I->click(['id' => 'installbutton_directory']);
-		$I->waitForText('was successful', '60', ['id' => 'system-message-container']);
+		$I->waitForText('was successful', 'TIMEOUT', ['id' => 'system-message-container']);
 		$this->debug("$type successfully installed from $path");
 	}
 
@@ -601,10 +604,10 @@ class JoomlaBrowser extends WebDriver
 		$I = $this;
 		$I->click(['xpath' => "//ul[@class='nav nav-user pull-right']//li//a[@class='dropdown-toggle']"]);
 		$this->debug("I click on Top Right corner toggle to Logout from Admin");
-		$I->waitForElement(['xpath' => "//li[@class='dropdown open']/ul[@class='dropdown-menu']//a[text() = 'Logout']"], 60);
+		$I->waitForElement(['xpath' => "//li[@class='dropdown open']/ul[@class='dropdown-menu']//a[text() = 'Logout']"], TIMEOUT);
 		$I->click(['xpath' => "//li[@class='dropdown open']/ul[@class='dropdown-menu']//a[text() = 'Logout']"]);
-		$I->waitForElement(['id' => 'mod-login-username'], 60);
-		$I->waitForText('Log in', 60, ['xpath' => "//fieldset[@class='loginform']//button"]);
+		$I->waitForElement(['id' => 'mod-login-username'], TIMEOUT);
+		$I->waitForText('Log in', TIMEOUT, ['xpath' => "//fieldset[@class='loginform']//button"]);
 	}
 
 	/**
@@ -664,7 +667,7 @@ class JoomlaBrowser extends WebDriver
 		$I->searchForItem($extensionName);
 		$I->waitForText(
 			'There are no extensions installed matching your query.',
-			60,
+			TIMEOUT,
 			['class' => 'alert-no-items']
 		);
 		$I->see('There are no extensions installed matching your query.', ['class' => 'alert-no-items']);
@@ -747,7 +750,7 @@ class JoomlaBrowser extends WebDriver
 		$I->waitForElement($this->searchResultLanguageName($languageName), 30);
 		$I->click(['id' => "cb0"]);
 		$I->click(['xpath' => "//div[@id='toolbar-upload']/button"]);
-		$I->waitForText('was successful.', 60, ['id' => 'system-message-container']);
+		$I->waitForText('was successful.', TIMEOUT, ['id' => 'system-message-container']);
 		$I->see('No Matching Results', ['class' => 'alert-no-items']);
 		$this->debug($languageName . ' successfully installed');
 	}
@@ -913,23 +916,23 @@ class JoomlaBrowser extends WebDriver
 
 		$I->debug("I open the menus page");
 		$I->amOnPage('administrator/index.php?option=com_menus&view=menus');
-		$I->waitForText('Menus', '60', ['css' => 'H1']);
+		$I->waitForText('Menus', 'TIMEOUT', ['css' => 'H1']);
 		$this->checkForPhpNoticesOrWarnings();
 
 		$I->debug("I click in the menu: $menu");
 		$I->click(['link' => $menu]);
-		$I->waitForText('Menus: Items', '60', ['css' => 'H1']);
+		$I->waitForText('Menus: Items', 'TIMEOUT', ['css' => 'H1']);
 		$this->checkForPhpNoticesOrWarnings();
 
 		$I->debug("I click new");
 		$I->click("New");
-		$I->waitForText('Menus: New Item', '60', ['css' => 'h1']);
+		$I->waitForText('Menus: New Item', 'TIMEOUT', ['css' => 'h1']);
 		$this->checkForPhpNoticesOrWarnings();
 		$I->fillField(['id' => 'jform_title'], $menuTitle);
 
 		$I->debug("Open the menu types iframe");
 		$I->click(['link' => "Select"]);
-		$I->waitForElement(['id' => 'menuTypeModal'], '60');
+		$I->waitForElement(['id' => 'menuTypeModal'], 'TIMEOUT');
 		$I->wait(1);
 		$I->switchToIFrame("Menu Item Type");
 
@@ -937,12 +940,12 @@ class JoomlaBrowser extends WebDriver
 
 		// Open the category
 		$I->wait(1);
-		$I->waitForElement(['link' => $menuCategory], '60');
+		$I->waitForElement(['link' => $menuCategory], 'TIMEOUT');
 		$I->click(['link' => $menuCategory]);
 
 		$I->debug("Choose the menu item type: $menuItem");
 		$I->wait(1);
-		$I->waitForElement(['xpath' => "//a[contains(text()[normalize-space()], '$menuItem')]"], '60');
+		$I->waitForElement(['xpath' => "//a[contains(text()[normalize-space()], '$menuItem')]"], 'TIMEOUT');
 		$I->click(['xpath' => "//div[@id='collapseTypes']//a[contains(text()[normalize-space()], '$menuItem')]"]);
 		$I->debug('I switch back to the main window');
 		$I->switchToIFrame();
@@ -953,7 +956,7 @@ class JoomlaBrowser extends WebDriver
 		$I->debug('I save the menu');
 		$I->click("Save");
 
-		$I->waitForText('Menu item successfully saved', '60', ['id' => 'system-message-container']);
+		$I->waitForText('Menu item successfully saved', 'TIMEOUT', ['id' => 'system-message-container']);
 	}
 
 	/**
@@ -1020,7 +1023,7 @@ class JoomlaBrowser extends WebDriver
 		$I = $this;
 		$this->debug('I click on never');
 		$I->wait(1);
-		$I->waitForElement(['link' => 'Never'], 60);
+		$I->waitForElement(['link' => 'Never'], TIMEOUT);
 		$I->click(['link' => 'Never']);
 	}
 }

--- a/src/locator/Locators.php
+++ b/src/locator/Locators.php
@@ -1,7 +1,15 @@
 <?php
 namespace Joomla\Browser\Locators;
 
-class Locators {
+/**
+ * Joomla Browser Locator class to hold selector value for the default theme
+ *
+ * Class Locators
+ *
+ * @since  1.6.5.1
+ */
+class Locators
+{
 
 	public $loginUserName = ['id' => 'username'];
 

--- a/src/locator/Locators.php
+++ b/src/locator/Locators.php
@@ -1,0 +1,29 @@
+<?php
+
+class Locators{
+
+	public static $loginUserName = ['id' => 'username'];
+
+	public static $loginPassword = ['id' => 'password'];
+
+	public static $loginButton = ['xpath' => "//div[@class='login']/form/fieldset/div[4]/div/button"];
+
+	public static $frontEndLoginSuccess = ['xpath' => "//form[@id='login-form']/div[@class='logout-button']"];
+
+	public static $frontEndLogoutButton = ['xpath' => "//div[@class='logout']//button[contains(text(), 'Log out')]"];
+
+	public static $frontEndLoginForm = ['xpath' => "//div[@class='login']//button[contains(text(), 'Log in')]"];
+
+	public static $adminLoginPageUrl = '/administrator/index.php';
+
+	public static $adminLoginUserName = ['id' => 'mod-login-username'];
+
+	public static $adminLoginPassword = ['id' => 'mod-login-password'];
+
+	public static $adminLoginButton = ['xpath' => "//button[contains(normalize-space(), 'Log in')]"];
+
+	public static $controlPanelLocator = ['css' => 'h1.page-title'];
+
+	public static $frontEndLoginUrl = '/index.php?option=com_users&view=login';
+
+}

--- a/src/locator/Locators.php
+++ b/src/locator/Locators.php
@@ -10,89 +10,99 @@ namespace Codeception\Module\Locators;
  */
 class Locators
 {
-
 	/**
 	 * Locator for the username field
-	 * @var 	array
-	 * @since   3.7.4.2
+	 *
+	 * @var    array
+	 * @since  3.7.4.2
 	 */
 	public $loginUserName = ['id' => 'username'];
 
 	/**
 	 * Locator for the Password field
-	 * @var 	array
-	 * @since   3.7.4.2
+	 *
+	 * @var    array
+	 * @since  3.7.4.2
 	 */
 	public $loginPassword = ['id' => 'password'];
 
 	/**
 	 * Locator for the Login Button
-	 * @var 	array
-	 * @since   3.7.4.2
+	 *
+	 * @var    array
+	 * @since  3.7.4.2
 	 */
 	public $loginButton = ['xpath' => "//div[@class='login']/form/fieldset/div[4]/div/button"];
 
 	/**
 	 * Locator for the Logout Button
-	 * @var 	array
-	 * @since   3.7.4.2
+	 * 
+	 * @var    array
+	 * @since  3.7.4.2
 	 */
 	public $frontEndLoginSuccess = ['xpath' => "//form[@id='login-form']/div[@class='logout-button']"];
 
 	/**
 	 * Locator for the Logout Button
-	 * @var 	array
-	 * @since   3.7.4.2
+	 * 
+	 * @var    array
+	 * @since  3.7.4.2
 	 */
 	public $frontEndLogoutButton = ['xpath' => "//div[@class='logout']//button[contains(text(), 'Log out')]"];
 
 	/**
 	 * Locator for the Login Button
-	 * @var 	array
-	 * @since   3.7.4.2
+	 * 
+	 * @var    array
+	 * @since  3.7.4.2
 	 */
 	public $frontEndLoginForm = ['xpath' => "//div[@class='login']//button[contains(text(), 'Log in')]"];
 
 	/**
 	 * Locator for the Login Page Url
-	 * @var 	array
-	 * @since   3.7.4.2
+	 * 
+	 * @var    array
+	 * @since  3.7.4.2
 	 */
 	public $adminLoginPageUrl = '/administrator/index.php';
 
 	/**
 	 * Locator for the administrator username field
-	 * @var 	array
-	 * @since   3.7.4.2
+	 * 
+	 * @var    array
+	 * @since  3.7.4.2
 	 */
 	public $adminLoginUserName = ['id' => 'mod-login-username'];
 
 	/**
 	 * Locator for the admin password field
-	 * @var 	array
-	 * @since   3.7.4.2
+	 * 
+	 * @var    array
+	 * @since  3.7.4.2
 	 */
 	public $adminLoginPassword = ['id' => 'mod-login-password'];
 
 	/**
 	 * Locator for the Login Button
-	 * @var 	array
-	 * @since   3.7.4.2
+	 * 
+	 * @var    array
+	 * @since  3.7.4.2
 	 */
 	public $adminLoginButton = ['xpath' => "//button[contains(normalize-space(), 'Log in')]"];
 
 	/**
 	 * Locator for the Control Panel
-	 * @var 	array
-	 * @since   3.7.4.2
+	 * 
+	 * @var    array
+	 * @since  3.7.4.2
 	 */
 	public $controlPanelLocator = ['css' => 'h1.page-title'];
 
 	/**
 	 * Locator for the Login URL
-	 * @var 	array
-	 * @since   3.7.4.2
+	 * 
+	 * @var    array
+	 * @since  3.7.4.2
 	 */
 	public $frontEndLoginUrl = '/index.php?option=com_users&view=login';
-
 }

--- a/src/locator/Locators.php
+++ b/src/locator/Locators.php
@@ -6,33 +6,93 @@ namespace Codeception\Module\Locators;
  *
  * Class Locators
  *
- * @since  1.6.5.1
+ * @since  3.7.4.2
  */
 class Locators
 {
 
+	/**
+	 * Locator for the username field
+	 * @var 	array
+	 * @since   3.7.4.2
+	 */
 	public $loginUserName = ['id' => 'username'];
 
+	/**
+	 * Locator for the Password field
+	 * @var 	array
+	 * @since   3.7.4.2
+	 */
 	public $loginPassword = ['id' => 'password'];
 
+	/**
+	 * Locator for the Login Button
+	 * @var 	array
+	 * @since   3.7.4.2
+	 */
 	public $loginButton = ['xpath' => "//div[@class='login']/form/fieldset/div[4]/div/button"];
 
+	/**
+	 * Locator for the Logout Button
+	 * @var 	array
+	 * @since   3.7.4.2
+	 */
 	public $frontEndLoginSuccess = ['xpath' => "//form[@id='login-form']/div[@class='logout-button']"];
 
+	/**
+	 * Locator for the Logout Button
+	 * @var 	array
+	 * @since   3.7.4.2
+	 */
 	public $frontEndLogoutButton = ['xpath' => "//div[@class='logout']//button[contains(text(), 'Log out')]"];
 
+	/**
+	 * Locator for the Login Button
+	 * @var 	array
+	 * @since   3.7.4.2
+	 */
 	public $frontEndLoginForm = ['xpath' => "//div[@class='login']//button[contains(text(), 'Log in')]"];
 
+	/**
+	 * Locator for the Login Page Url
+	 * @var 	array
+	 * @since   3.7.4.2
+	 */
 	public $adminLoginPageUrl = '/administrator/index.php';
 
+	/**
+	 * Locator for the administrator username field
+	 * @var 	array
+	 * @since   3.7.4.2
+	 */
 	public $adminLoginUserName = ['id' => 'mod-login-username'];
 
+	/**
+	 * Locator for the admin password field
+	 * @var 	array
+	 * @since   3.7.4.2
+	 */
 	public $adminLoginPassword = ['id' => 'mod-login-password'];
 
+	/**
+	 * Locator for the Login Button
+	 * @var 	array
+	 * @since   3.7.4.2
+	 */
 	public $adminLoginButton = ['xpath' => "//button[contains(normalize-space(), 'Log in')]"];
 
+	/**
+	 * Locator for the Control Panel
+	 * @var 	array
+	 * @since   3.7.4.2
+	 */
 	public $controlPanelLocator = ['css' => 'h1.page-title'];
 
+	/**
+	 * Locator for the Login URL
+	 * @var 	array
+	 * @since   3.7.4.2
+	 */
 	public $frontEndLoginUrl = '/index.php?option=com_users&view=login';
 
 }

--- a/src/locator/Locators.php
+++ b/src/locator/Locators.php
@@ -1,5 +1,5 @@
 <?php
-namespace Joomla\Browser\Locators;
+namespace Codeception\Module\Locators;
 
 /**
  * Joomla Browser Locator class to hold selector value for the default theme

--- a/src/locator/Locators.php
+++ b/src/locator/Locators.php
@@ -1,29 +1,30 @@
 <?php
+namespace Joomla\Browser\Locators;
 
-class Locators{
+class Locators {
 
-	public static $loginUserName = ['id' => 'username'];
+	public $loginUserName = ['id' => 'username'];
 
-	public static $loginPassword = ['id' => 'password'];
+	public $loginPassword = ['id' => 'password'];
 
-	public static $loginButton = ['xpath' => "//div[@class='login']/form/fieldset/div[4]/div/button"];
+	public $loginButton = ['xpath' => "//div[@class='login']/form/fieldset/div[4]/div/button"];
 
-	public static $frontEndLoginSuccess = ['xpath' => "//form[@id='login-form']/div[@class='logout-button']"];
+	public $frontEndLoginSuccess = ['xpath' => "//form[@id='login-form']/div[@class='logout-button']"];
 
-	public static $frontEndLogoutButton = ['xpath' => "//div[@class='logout']//button[contains(text(), 'Log out')]"];
+	public $frontEndLogoutButton = ['xpath' => "//div[@class='logout']//button[contains(text(), 'Log out')]"];
 
-	public static $frontEndLoginForm = ['xpath' => "//div[@class='login']//button[contains(text(), 'Log in')]"];
+	public $frontEndLoginForm = ['xpath' => "//div[@class='login']//button[contains(text(), 'Log in')]"];
 
-	public static $adminLoginPageUrl = '/administrator/index.php';
+	public $adminLoginPageUrl = '/administrator/index.php';
 
-	public static $adminLoginUserName = ['id' => 'mod-login-username'];
+	public $adminLoginUserName = ['id' => 'mod-login-username'];
 
-	public static $adminLoginPassword = ['id' => 'mod-login-password'];
+	public $adminLoginPassword = ['id' => 'mod-login-password'];
 
-	public static $adminLoginButton = ['xpath' => "//button[contains(normalize-space(), 'Log in')]"];
+	public $adminLoginButton = ['xpath' => "//button[contains(normalize-space(), 'Log in')]"];
 
-	public static $controlPanelLocator = ['css' => 'h1.page-title'];
+	public $controlPanelLocator = ['css' => 'h1.page-title'];
 
-	public static $frontEndLoginUrl = '/index.php?option=com_users&view=login';
+	public $frontEndLoginUrl = '/index.php?option=com_users&view=login';
 
 }


### PR DESCRIPTION
currently Joomla Browser only supports locators for Protostar template, but when testing against extensions which has custom Template, all the methods fail because of wrong locators, with this PR, I am trying to establish an option in which Extension developers can pass their custom Locators class, It works like Page Object class. The new function ``instantiateLocator`` checks if any custom Template locator has been provided in the acceptance.suite.yml file and then instantiates the locator object with custom Template locator. 

Just by adding this in Acceptance Suite file 
![image](https://cloud.githubusercontent.com/assets/3048593/26073874/b05c986a-39cd-11e7-93e1-22c38020e638.png)
This PR makes sure, no changes are required in the existing system and no failures occur because of this change, extension developers who are using Joomla Browser will have an option to use this feature if they want to. 