### PR TITLE
Added method to create a new category (com_categories)

### DIFF
--- a/src/JoomlaBrowser.php
+++ b/src/JoomlaBrowser.php
@@ -46,7 +46,7 @@ class JoomlaBrowser extends WebDriver
 	/**
 	 * The locator
 	 *
-	 * @var     Codeception\Module\Locators\Locators
+	 * @var     Locators
 	 * @since   3.7.4.2
 	 */
 	protected $locator;
@@ -1130,7 +1130,7 @@ class JoomlaBrowser extends WebDriver
 		$this->checkForPhpNoticesOrWarnings();
 
 		$this->debug('Click new category button');
-		$this->click(['class' => 'button-new']);
+		$this->click($this->locator->adminToolbarButtonNew);
 
 		$this->waitForElement(['class' => 'page-title']);
 
@@ -1138,7 +1138,7 @@ class JoomlaBrowser extends WebDriver
 		$this->fillField(['id' => 'jform_title'], $title);
 
 		$this->debug('Click new category apply button');
-		$this->click(['class' => 'button-apply']);
+		$this->click($this->locator->adminToolbarButtonApply);
 
 		$this->debug('see a success message after saving the category');
 

--- a/src/JoomlaBrowser.php
+++ b/src/JoomlaBrowser.php
@@ -1103,4 +1103,46 @@ class JoomlaBrowser extends WebDriver
 		$this->waitForElement(['link' => 'Never'], TIMEOUT);
 		$this->click(['link' => 'Never']);
 	}
+
+	/**
+	 * Create a new category
+	 *
+	 * @param   string  $title      Title of the new category
+	 * @param   string  $extension  Optional extension to use
+	 *
+	 * @return  void
+	 *
+	 * @since   3.7.5
+	 */
+	public function createCategory($title, $extension = '')
+	{
+		$this->debug('Category creation in /administrator/');
+		$this->doAdministratorLogin();
+
+		if (!empty($extension))
+		{
+			$extension = '&extension=' . $extension;
+		}
+
+		$this->amOnPage('administrator/index.php?option=com_categories' . $extension);
+
+		$this->waitForElement(['class' => 'page-title']);
+		$this->checkForPhpNoticesOrWarnings();
+
+		$this->debug('Click new category button');
+		$this->click(['class' => 'button-new']);
+
+		$this->waitForElement(['class' => 'page-title']);
+
+		$this->checkForPhpNoticesOrWarnings();
+		$this->fillField(['id' => 'jform_title'], $title);
+
+		$this->debug('Click new category apply button');
+		$this->click(['class' => 'button-apply']);
+
+		$this->debug('see a success message after saving the category');
+
+		$this->see('Category saved', ['id' => 'system-message-container']);
+		$this->checkForPhpNoticesOrWarnings();
+	}
 }

--- a/src/Locators/Locators.php
+++ b/src/Locators/Locators.php
@@ -105,4 +105,20 @@ class Locators
 	 * @since  3.7.4.2
 	 */
 	public $frontEndLoginUrl = '/index.php?option=com_users&view=login';
+
+	/**
+	 * New Button in the Admin toolbar
+	 *
+	 * @var    array
+	 * @since  3.7.5
+	 */
+	public $adminToolbarButtonNew = ['class' => 'button-new'];
+
+	/**
+	 * Apply Button in the Admin toolbar
+	 *
+	 * @var    array
+	 * @since  3.7.5
+	 */
+	public $adminToolbarButtonApply = ['class' => 'button-apply'];
 }


### PR DESCRIPTION
Create a new category in Joomla (in com_categories) with the given title and extension. No other options set.

Usage:

`$I->createCategory('New com_content category');`

With an custom extension:

`$I->createCategory('New weblinks category', 'com_weblinks');`

