### PR TITLE
Adding the Control Panel text in Locator File

### DIFF
--- a/src/JoomlaBrowser.php
+++ b/src/JoomlaBrowser.php
@@ -134,7 +134,7 @@ class JoomlaBrowser extends WebDriver
 		$this->debug('I click Login button');
 		$this->click($this->locator->adminLoginButton);
 		$this->debug('I wait to see Administrator Control Panel');
-		$this->waitForText('Control Panel', 4, $this->locator->controlPanelLocator);
+		$this->waitForText($this->locator->adminControlPanelText, 4, $this->locator->controlPanelLocator);
 	}
 
 	/**

--- a/src/Locators/Locators.php
+++ b/src/Locators/Locators.php
@@ -121,4 +121,12 @@ class Locators
 	 * @since  3.7.5
 	 */
 	public $adminToolbarButtonApply = ['class' => 'button-apply'];
+
+	/**
+	 * Admin Control Panel Text
+	 *
+	 * @var    array
+	 * @since  3.7.5
+	 */
+	public $adminControlPanelText = 'Control Panel';
 }


### PR DESCRIPTION
The Control Panel String was missing from Locator Class, which was making it difficult to load custom text to test a Joomla Site which had a different Default Language other than English.