### PR TITLE
[fix] Ensured the login page is loaded before looking for cookies

### DIFF
--- a/src/JoomlaBrowser.php
+++ b/src/JoomlaBrowser.php
@@ -123,13 +123,14 @@ class JoomlaBrowser extends WebDriver
 			$password = $this->config['password'];
 		}
 
+		$this->debug('I open Joomla Administrator Login Page');
+		$this->amOnPage($this->locator->adminLoginPageUrl);
+
 		if ($useSnapshot && $this->loadSessionSnapshot($user))
 		{
 			return;
 		}
 
-		$this->debug('I open Joomla Administrator Login Page');
-		$this->amOnPage($this->locator->adminLoginPageUrl);
 		$this->waitForElement($this->locator->adminLoginUserName, TIMEOUT);
 		$this->debug('Fill Username Text Field');
 		$this->fillField($this->locator->adminLoginUserName, $user);


### PR DESCRIPTION
This prevents an error "unable to set cookie" happening with certain Selenium builds that need to pre-load the page where the cookies are set, before using them