### PR TITLE
Fix Spanish language detection

### DIFF
--- a/src/JoomlaBrowser.php
+++ b/src/JoomlaBrowser.php
@@ -264,7 +264,7 @@ class JoomlaBrowser extends WebDriver
 		$this->debug('I select es-ES as installation language');
 
 		// Select a random language to force reloading of the lang strings after selecting English
-		$this->selectOptionInChosenWithTextField('#jform_language', 'Spanish (Español)');
+		$this->selectOptionInChosenWithTextField('#jform_language', 'Español (España)');
 		$this->waitForText('Configuración principal', TIMEOUT, 'h3');
 
 		// Wait for chosen to render the field


### PR DESCRIPTION
The installer currently breaks because the Spanish language can't be found. Not sure if this fixes also the broken system tests in 4. I had to apply this fix to make the DPCalendar system tests working again.