### PR TITLE
Update deprecated license …

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description"   : "joomla-browser Codeception Module",
     "keywords"      : ["BDD", "acceptance testing", "tdd", "joomla"],
     "homepage"      : "https://docs.joomla.org/Testing_Joomla_Extensions_with_Codeception",
-    "license"       : "GPL-2.0+",
+    "license"       : "GPL-2.0-or-later",
     "authors"       : [
         {
           "name"    : "Puneet Kala",


### PR DESCRIPTION
The spdx have deprecated the short license identifier GPL-2.0+ and we should use GPL-2.0-or-later
https://spdx.org/licenses/