### PR TITLE
Codeception test for template "khonsu"

### DIFF
--- a/src/JoomlaBrowser.php
+++ b/src/JoomlaBrowser.php
@@ -353,7 +353,7 @@ class JoomlaBrowser extends WebDriver
 
 		$this->acceptPopup();
 
-		// // Wait until the installation folder is gone and the "customize installation" box has been removed
+		// Wait until the installation folder is gone and the "customize installation" box has been removed
 		$this->waitForElementNotVisible(['id' => 'installAddFeatures']);
 
 		$this->debug('Joomla is now installed');

--- a/src/JoomlaBrowser.php
+++ b/src/JoomlaBrowser.php
@@ -130,6 +130,9 @@ class JoomlaBrowser extends WebDriver
 			return;
 		}
 
+		// Wait for preparing the login page
+		$this->wait(2);
+
 		$this->debug('I open Joomla Administrator Login Page');
 		$this->amOnPage($this->locator->adminLoginPageUrl);
 		$this->waitForElement($this->locator->adminLoginUserName, TIMEOUT);
@@ -238,13 +241,16 @@ class JoomlaBrowser extends WebDriver
 		$this->debug('I select en-GB as installation language');
 		$this->debug('Wait for chosen to render the Languages list field');
 		$this->selectOption('#jform_language', 'English (United Kingdom)');
+		$this->click(['id' => 'step0']);
+
+		// Wait for fill the site name and site email
 		$this->debug('I fill Site Name');
 		$this->fillField(['id' => 'jform_site_name'], 'Joomla CMS test');
+		$this->debug('I fill Admin Email');
+		$this->fillField(['id' => 'jform_admin_email'], $this->config['admin email']);
 		$this->click(['id' => 'step1']);
 
 		// I get the configuration from acceptance.suite.yml (see: tests/_support/acceptancehelper.php)
-		$this->debug('I fill Admin Email');
-		$this->fillField(['id' => 'jform_admin_email'], $this->config['admin email']);
 		$this->debug('I fill Admin Name');
 		$this->fillField(['id' => 'jform_admin_user'], $this->config['name']);
 		$this->debug('I fill Admin Username');
@@ -270,7 +276,7 @@ class JoomlaBrowser extends WebDriver
 		$this->debug('I click Install Joomla Button');
 		$this->click(['id' => 'setupButton']);
 		$this->wait(1);
-		$this->waitForText('Congratulations! Your Joomla site is ready.', TIMEOUT, ['xpath' => '//h2']);
+		$this->waitForText('Please wait while your site is installing…', TIMEOUT, ['xpath' => '//p']);
 	}
 
 	/**
@@ -283,19 +289,20 @@ class JoomlaBrowser extends WebDriver
 	public function installJoomlaRemovingInstallationFolder()
 	{
 		$this->installJoomla();
-
+		$this->wait(2);
+		$this->amOnPage('/installation/index.php');
 		$this->debug('Removing Installation Folder');
 		$this->click(['id' => 'removeInstallationFolder']);
 
 		// Accept the confirmation alert
-		$this->seeInPopup('Are you sure you want to delete?');
+		$this->seeInPopup('Are you sure you want to delete? Confirming will permanently delete the installation folder.');
 		$this->acceptPopup();
 
 		// Wait until the installation folder is gone and the "customize installation" box has been removed
 		$this->waitForElementNotVisible(['id' => 'installAddFeatures']);
 
 		$this->debug('Joomla is now installed');
-		$this->click(['link' => "Complete & Open Admin"]);
+		$this->click(['link' => "Open Admin"]);
 	}
 
 	/**

--- a/src/JoomlaBrowser.php
+++ b/src/JoomlaBrowser.php
@@ -53,12 +53,12 @@ class JoomlaBrowser extends WebDriver
 	protected $locator;
 
 	/**
-	 * If the test run for spring template
+	 * If the test run for "khonsu" template
 	 *
 	 * @var		boolean
 	 * @since	4.0.0
 	 */
-	protected $isSpringTemplate = false;
+	protected $isKhonsu = false;
 
 	/**
 	 * Module constructor.
@@ -74,9 +74,9 @@ class JoomlaBrowser extends WebDriver
 	{
 		parent::__construct($moduleContainer, $config);
 
-		// Check if the backend template is spring or not
-		$this->isSpringTemplate = isset($this->config['backend_template'])
-			&& $this->config['backend_template'] === 'spring';
+		// Check if the backend template is "khonsu" or not
+		$this->isKhonsu = isset($this->config['backend_template'])
+			&& $this->config['backend_template'] === 'khonsu';
 
 		// Instantiate the locator
 		$this->instantiateLocator();
@@ -142,7 +142,7 @@ class JoomlaBrowser extends WebDriver
 			return;
 		}
 
-		if ($this->isSpringTemplate)
+		if ($this->isKhonsu)
 		{
 			// Wait for preparing the login page
 			$this->wait(2);
@@ -257,7 +257,7 @@ class JoomlaBrowser extends WebDriver
 		$this->debug('Wait for chosen to render the Languages list field');
 		$this->selectOption('#jform_language', 'English (United Kingdom)');
 
-		if ($this->isSpringTemplate)
+		if ($this->isKhonsu)
 		{
 			$this->click(['id' => 'step0']);
 		}
@@ -266,8 +266,8 @@ class JoomlaBrowser extends WebDriver
 		$this->debug('I fill Site Name');
 		$this->fillField(['id' => 'jform_site_name'], 'Joomla CMS test');
 
-		// If the backend template is "spring" then fill the site email in this step
-		if ($this->isSpringTemplate)
+		// If the backend template is "khonsu" then fill the site email in this step
+		if ($this->isKhonsu)
 		{
 			$this->debug('I fill Admin Email');
 			$this->fillField(['id' => 'jform_admin_email'], $this->config['admin email']);
@@ -275,8 +275,8 @@ class JoomlaBrowser extends WebDriver
 
 		$this->click(['id' => 'step1']);
 
-		// If backend template is not "spring" then fill admin email after clicking #step1
-		if (!$this->isSpringTemplate)
+		// If backend template is not "khonsu" then fill admin email after clicking #step1
+		if (!$this->isKhonsu)
 		{
 			$this->debug('I fill Admin Email');
 			$this->fillField(['id' => 'jform_admin_email'], $this->config['admin email']);
@@ -310,7 +310,7 @@ class JoomlaBrowser extends WebDriver
 		$this->wait(1);
 
 		// Check the text after clicking setupButton
-		if ($this->isSpringTemplate)
+		if ($this->isKhonsu)
 		{
 			$this->waitForText('Please wait while your site is installing…', TIMEOUT, ['xpath' => '//p']);
 		}
@@ -331,8 +331,8 @@ class JoomlaBrowser extends WebDriver
 	{
 		$this->installJoomla();
 
-		// For template "spring" wait 2 sec after installation finished
-		if ($this->isSpringTemplate)
+		// For template "khonsu" wait 2 sec after installation finished
+		if ($this->isKhonsu)
 		{
 			$this->wait(2);
 			$this->amOnPage('/installation/index.php');
@@ -342,7 +342,7 @@ class JoomlaBrowser extends WebDriver
 		$this->click(['id' => 'removeInstallationFolder']);
 
 		// Accept the confirmation alert
-		if ($this->isSpringTemplate)
+		if ($this->isKhonsu)
 		{
 			$this->seeInPopup('Are you sure you want to delete? Confirming will permanently delete the installation folder.');
 		}
@@ -358,7 +358,7 @@ class JoomlaBrowser extends WebDriver
 
 		$this->debug('Joomla is now installed');
 
-		if ($this->isSpringTemplate)
+		if ($this->isKhonsu)
 		{
 			$this->click(['link' => "Open Admin"]);
 		}


### PR DESCRIPTION
This pull request fixes the #197 for the backend template "khonsu".

The problem is the "khonsu" template has a different DOM structure than "atum" template. So there needs to update some of the commands on the JoomlaBrowser.php file with full compatibility of the previous one.

For this, there needs to add a config key backend_template: 'khonsu' under modules > config > JoomlaBrowser on the acceptance.suite.yml file.

This PR will allow the https://github.com/joomla-projects/j4adminui repository to pass the drone test.