### PR TITLE
Add wait for removeInstallationFolder button

### DIFF
--- a/src/JoomlaBrowser.php
+++ b/src/JoomlaBrowser.php
@@ -331,12 +331,8 @@ class JoomlaBrowser extends WebDriver
 	{
 		$this->installJoomla();
 
-		// For template "khonsu" wait 2 sec after installation finished
-		if ($this->isKhonsu)
-		{
-			$this->wait(2);
-			$this->amOnPage('/installation/index.php');
-		}
+		// Wait for the visibility of #removeInstallationFolder Element
+		$this->waitForElementVisible("#removeInstallationFolder", TIMEOUT);
 
 		$this->debug('Removing Installation Folder');
 		$this->click(['id' => 'removeInstallationFolder']);


### PR DESCRIPTION
The installation takes some period to complete and for that, we need to wait for `#removeInstallationFolder` button to visible before clicking it. 

Added `waitForElementVisible()` for `#removeInstallationFolder` button.