### PR TITLE
Allow the creation of a new user with the default user group.

### DIFF
--- a/src/JoomlaBrowser.php
+++ b/src/JoomlaBrowser.php
@@ -1,7 +1,5 @@
 <?php
 /**
- * @package    JoomlaBrowser
- *
  * @copyright  Copyright (C) 2005 - 2018 Open Source Matters, Inc. All rights reserved.
  * @license    GNU General Public License version 2 or later; see LICENSE.txt
  */

--- a/src/JoomlaBrowser.php
+++ b/src/JoomlaBrowser.php
@@ -1280,7 +1280,8 @@ class JoomlaBrowser extends WebDriver
 		$this->fillField(array('id' => 'jform_password2'), $password);
 		$this->fillField(array('id' => 'jform_email'), $email);
 
-		if (!empty($userGroup)) {
+		if (!empty($userGroup)) 
+		{
 			$this->debug('I open the Assigned User Groups Tab and assign the user group');
 			$this->click(array('link' => 'Assigned User Groups'));
 			$this->click(array('xpath' => "//label[contains(text()[normalize-space()], '$userGroup')]"));

--- a/src/JoomlaBrowser.php
+++ b/src/JoomlaBrowser.php
@@ -1280,9 +1280,11 @@ class JoomlaBrowser extends WebDriver
 		$this->fillField(array('id' => 'jform_password2'), $password);
 		$this->fillField(array('id' => 'jform_email'), $email);
 
-		$this->debug('I open the Assigned User Groups Tab and assign the user group');
-		$this->click(array('link' => 'Assigned User Groups'));
-		$this->click(array('xpath' => "//label[contains(text()[normalize-space()], '$userGroup')]"));
+		if (!empty($userGroup)) {
+			$this->debug('I open the Assigned User Groups Tab and assign the user group');
+			$this->click(array('link' => 'Assigned User Groups'));
+			$this->click(array('xpath' => "//label[contains(text()[normalize-space()], '$userGroup')]"));
+		}
 
 		$this->debug('Click new user apply button');
 		$this->click($this->locator->adminToolbarButtonApply);

--- a/src/JoomlaBrowser.php
+++ b/src/JoomlaBrowser.php
@@ -1281,8 +1281,8 @@ class JoomlaBrowser extends WebDriver
 		if (!empty($userGroup))
 		{
 			$this->debug('I open the Assigned User Groups Tab and assign the user group');
-			$this->click(array('link' => 'Assigned User Groups'));
-			$this->click(array('xpath' => "//label[contains(text()[normalize-space()], '$userGroup')]"));
+			$this->click($this->locator->adminManageUsersUserGroupAssignmentTab);
+			$this->click($this->locator->adminManageUsersUserGroupAssignmentCheckbox($userGroup));
 		}
 
 		$this->debug('Click new user apply button');

--- a/src/JoomlaBrowser.php
+++ b/src/JoomlaBrowser.php
@@ -1280,7 +1280,7 @@ class JoomlaBrowser extends WebDriver
 		$this->fillField(array('id' => 'jform_password2'), $password);
 		$this->fillField(array('id' => 'jform_email'), $email);
 
-		if (!empty($userGroup)) 
+		if (!empty($userGroup))
 		{
 			$this->debug('I open the Assigned User Groups Tab and assign the user group');
 			$this->click(array('link' => 'Assigned User Groups'));

--- a/src/Locators/Locators.php
+++ b/src/Locators/Locators.php
@@ -1,7 +1,5 @@
 <?php
 /**
- * @package    JoomlaBrowser
- *
  * @copyright  Copyright (C) 2005 - 2018 Open Source Matters, Inc. All rights reserved.
  * @license    GNU General Public License version 2 or later; see LICENSE.txt
  */
@@ -136,4 +134,25 @@ class Locators
 	 * @since  3.7.5
 	 */
 	public $adminControlPanelText = 'Control Panel';
+
+	/**
+	 * Manage User - User Group Assignment Tab
+	 *
+	 * @var    string
+	 * @since  3.9.1
+	 */
+	public $adminManageUsersUserGroupAssignmentTab = array('link' => 'Assigned User Groups');
+
+	/**
+	 * Manage User - User Group Assignment Tab - User Group checkbox
+	 *
+	 * @param   string $userGroup display name of the user group
+	 * @return array
+	 * @since  3.9.1
+	 */
+	public function adminManageUsersUserGroupAssignmentCheckbox($userGroup)
+	{
+		return array('xpath' => "//label[contains(text()[normalize-space()], '$userGroup')]");
+	}
+
 }


### PR DESCRIPTION
If we want to create a registered user, the value `Registered` would remove the checkbox in the user group assignment tab and causes an error. This modification will allow us to pass in an empty user group string and skip the change in the user group assignment tab. 