### PR TITLE
Wait until the install page gets interactive. Clicking to early on th…

### DIFF
--- a/src/JoomlaBrowser.php
+++ b/src/JoomlaBrowser.php
@@ -498,7 +498,7 @@ class JoomlaBrowser extends WebDriver
 	{
 		$this->amOnPage('/administrator/index.php?option=com_installer');
 		$this->waitForText('Extensions: Install', '30', array('css' => 'H1'));
-		
+
 		// The page needs some time to get interactive.
 		$this->wait(1);
 		$this->click(array('link' => 'Install from URL'));

--- a/src/JoomlaBrowser.php
+++ b/src/JoomlaBrowser.php
@@ -498,7 +498,8 @@ class JoomlaBrowser extends WebDriver
 	{
 		$this->amOnPage('/administrator/index.php?option=com_installer');
 		$this->waitForText('Extensions: Install', '30', array('css' => 'H1'));
-		// the page needs some time to get interactive
+		
+		// The page needs some time to get interactive.
 		$this->wait(1);
 		$this->click(array('link' => 'Install from URL'));
 		$this->debug('I enter the url');

--- a/src/JoomlaBrowser.php
+++ b/src/JoomlaBrowser.php
@@ -498,6 +498,8 @@ class JoomlaBrowser extends WebDriver
 	{
 		$this->amOnPage('/administrator/index.php?option=com_installer');
 		$this->waitForText('Extensions: Install', '30', array('css' => 'H1'));
+		// the page needs some time to get interactive
+		$this->wait(1);
 		$this->click(array('link' => 'Install from URL'));
 		$this->debug('I enter the url');
 		$this->fillField(array('id' => 'install_url'), $url);


### PR DESCRIPTION
Wait until the install page gets interactive. Clicking to early on the tab will not cause a tab switch and the input field is not accessible.